### PR TITLE
Dummy run that emits 'end' but not saves

### DIFF
--- a/lib/dest/index.js
+++ b/lib/dest/index.js
@@ -7,6 +7,14 @@ var writeContents = require('./writeContents');
 var defaultMode = 0777 & (~process.umask());
 
 module.exports = function(outFolder, opt) {
+  if (!outFolder) {
+    function dummy(file, cb) {
+      cb(null, null);
+    }
+    var stream = map(dummy);
+    return stream;
+  };
+
   if (!opt) opt = {};
   if (!opt.cwd) opt.cwd = process.cwd();
   if (typeof opt.mode === 'string') opt.mode = parseInt(opt.mode, 8);
@@ -15,7 +23,7 @@ module.exports = function(outFolder, opt) {
   var basePath = path.resolve(cwd, outFolder);
   var folderMode = (opt.mode || defaultMode);
 
-  function saveFile (file, cb) {
+  function saveFile(file, cb) {
     var writePath = path.resolve(basePath, file.relative);
     var writeFolder = path.dirname(writePath);
 


### PR DESCRIPTION
After this change `gulp-shell`+`jshint` are compatible with callback way. You see - i dont need to dump "index.js" anywhere. So, full `gulp.dest` is not needed. Here is the example:

```
gulp.task('lint', function(cb) {

  gulp.src("index.js")
      .pipe(shell('jshint <%= file.path %>'))
      .pipe(gulp.dest()) // "end" does not fire if you comment this line
      .once("end", function() {

    console.log("ended!");
    cb();

    // here may be some more code with cb()
    // inside. so cb-way is preferred

  });

});
```
