### PR TITLE
Allow function for outFolder in dest

### DIFF
--- a/lib/dest/index.js
+++ b/lib/dest/index.js
@@ -7,17 +7,22 @@ var writeContents = require('./writeContents');
 var defaultMode = 0777 & (~process.umask());
 
 module.exports = function(outFolder, opt) {
-  if (typeof outFolder !== 'string') throw new Error('Invalid output folder');
-
   if (!opt) opt = {};
   if (!opt.cwd) opt.cwd = process.cwd();
   if (typeof opt.mode === 'string') opt.mode = parseInt(opt.mode, 8);
 
   var cwd = path.resolve(opt.cwd);
-  var basePath = path.resolve(cwd, outFolder);
   var folderMode = (opt.mode || defaultMode);
+  var basePath;
+
+  if (typeof outFolder === 'string') {
+    basePath = path.resolve(cwd, outFolder);
+  } else if (typeof outFolder !== 'function') {
+    throw new Error('Invalid output folder');
+  }
 
   function saveFile (file, cb) {
+    if (typeof outFolder === 'function') basePath = path.resolve(cwd, outFolder(file));
     var writePath = path.resolve(basePath, file.relative);
     var writeFolder = path.dirname(writePath);
 


### PR DESCRIPTION
We use a PHP framework that stores assets within bundles. We want to use gulp to compile these assets but there are a large quantity of the bundles. It is obviously possible to set up a pipelines for each using a loop, but we would end up with 100's.

I propose allowing passing a function as `outFolder` to `dest`, so that the input file info can be used to manipulate the output path. I attempted to create a plugin to do this but it just ended up as a copy of `dest`, so decided a PR would be much cleaner. I think this feature will be useful to others, and doesn't add too much code.

It's only a proposal at this point so I haven't taken the time to write a test or document it, but if you are interested let me know and I will produce both of these.
