### PR TITLE
fix(src): ignore files in incoming stream(s)

### DIFF
--- a/lib/src/index.js
+++ b/lib/src/index.js
@@ -1,5 +1,6 @@
 var map = require('map-stream');
 var gs = require('glob-stream');
+var duplex = require('duplexer');
 
 var File = require('vinyl');
 var getContents = require('./getContents');
@@ -10,6 +11,19 @@ var validateGlob = function(glob) {
   if (typeof glob !== 'string' && !isArr) return false;
   if (isArr && isArr.length === 0) return false;
   return true;
+};
+
+/**
+ * Create a through stream that will ignore incoming readable streams.
+ * @param  {stream.Readable} the readable stream
+ * @return {stream.Duplex} a through stream that ignores incoming streams.
+ */
+var ignoreIncoming = function(outgoingStream) {
+  var incomingStream = map(function(data, callback) {
+    callback();
+  });
+  // the incoming stream is not connected to the outgoing stream
+  return duplex(incomingStream, outgoingStream);
 };
 
 module.exports = function(glob, opt) {
@@ -30,5 +44,5 @@ module.exports = function(glob, opt) {
 
   if (!opt.read) return stream; // no reading required
 
-  return stream.pipe(getContents(opt));
+  return ignoreIncoming(stream.pipe(getContents(opt)));
 };

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "glob-watcher": "^0.0.6",
     "mkdirp": "^0.3.5",
     "graceful-fs": "^2.0.1",
-    "map-stream": "^0.1.0"
+    "map-stream": "^0.1.0",
+    "duplexer": "^0.1.1"
   },
   "devDependencies": {
     "mocha": "^1.17.0",


### PR DESCRIPTION
If streams are piped into the src through stream, ignore any files that come from them.

Effectively, the src function resets the files in the stream to those that match its pattern(s)/option(s).

Closes #16
