### PR TITLE
Removed through2-map dependency

### DIFF
--- a/lib/src/index.js
+++ b/lib/src/index.js
@@ -2,18 +2,15 @@
 
 var defaults = require('lodash.defaults');
 var through = require('through2');
-var map = require('through2-map');
 var gs = require('glob-stream');
 var File = require('vinyl');
 
 var getContents = require('./getContents');
 var getStats = require('./getStats');
 
-var formatStream = map.ctor({
-  objectMode: true
-}, function (globFile) {
-  return new File(globFile);
-});
+function createFile (globFile, enc, cb) {
+  cb(null, new File(globFile));
+}
 
 function src(glob, opt) {
   if (!isValidGlob(glob)) {
@@ -29,7 +26,7 @@ function src(glob, opt) {
 
   // when people write to use just pass it through
   var outputStream = globStream
-    .pipe(formatStream())
+    .pipe(through.obj(createFile))
     .pipe(getStats(options));
 
   if (options.read !== false) {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "mkdirp": "^0.5.0",
     "strip-bom": "^0.3.0",
     "through2": "^0.5.1",
-    "through2-map": "^1.3.0",
     "vinyl": "^0.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
It can be easily achieved by `through2.obj` with a transform function.
