### PR TITLE
Use readFileSync and writeFileSync for better performance

### DIFF
--- a/lib/dest/writeContents/writeBuffer.js
+++ b/lib/dest/writeContents/writeBuffer.js
@@ -7,7 +7,13 @@ function writeBuffer(writePath, file, cb) {
     mode: file.stat.mode
   };
 
-  fs.writeFile(writePath, file.contents, opt, cb);
+  try {
+    fs.writeFileSync(writePath, file.contents, opt);
+  } catch (err) {
+    return cb(err);
+  }
+
+  cb();
 }
 
 module.exports = writeBuffer;

--- a/lib/src/getContents/bufferFile.js
+++ b/lib/src/getContents/bufferFile.js
@@ -4,13 +4,15 @@ var fs = require('graceful-fs');
 var stripBom = require('strip-bom');
 
 function bufferFile(file, cb) {
-  fs.readFile(file.path, function (err, data) {
-    if (err) {
-      return cb(err);
-    }
-    file.contents = stripBom(data);
-    cb(null, file);
-  });
+  var data;
+  try {
+    data = fs.readFileSync(file.path);
+  } catch (err) {
+    return cb(err);
+  }
+
+  file.contents = stripBom(data);
+  cb(null, file);
 }
 
 module.exports = bufferFile;

--- a/lib/src/getStats.js
+++ b/lib/src/getStats.js
@@ -8,12 +8,13 @@ function getStats() {
 }
 
 function fetchStats(file, enc, cb) {
-  fs.stat(file.path, function (err, stat) {
-    if (stat) {
-      file.stat = stat;
-    }
-    cb(err, file);
-  });
+  try {
+    file.stat = fs.statSync(file.path);
+  } catch (err) {
+    return cb(err, file);
+  }
+
+  cb(null, file);
 }
 
 module.exports = getStats;


### PR DESCRIPTION
Asynchronous functions have very unreliable performance, taking from 1ms up to 600ms.
Synchronous fs functions give much better and predictable performance (~1ms).

Related issue: https://github.com/gulpjs/gulp/issues/568

PS Not sure if you're ready to accept it, but this is currently a pressing issue for me (makes Gulp unusable). I'm assuming `vinyl-fs` is used for the build tools and runs on desktop, so there is no penalty for sync calls. This could be made configurable though.
