### PR TITLE
Display the invalid glob in error message

### DIFF
--- a/lib/src/index.js
+++ b/lib/src/index.js
@@ -14,7 +14,7 @@ function createFile (globFile, enc, cb) {
 
 function src(glob, opt) {
   if (!isValidGlob(glob)) {
-    throw new Error('Invalid glob argument');
+    throw new Error('Invalid glob argument: ' + glob);
   }
 
   var options = defaults({}, opt, {


### PR DESCRIPTION
The current error message for displaying a glob can be improved by including the invalid glob in the error message. This makes it easy for developers to debug exactly which glob is incorrect.
