### PR TITLE
use default mode for new files and directories

### DIFF
--- a/lib/dest/index.js
+++ b/lib/dest/index.js
@@ -10,8 +10,6 @@ var fs = require('graceful-fs');
 
 var writeContents = require('./writeContents');
 
-// 511 = 0777
-var processMode = 511 & (~process.umask());
 
 function dest(outFolder, opt) {
   if (typeof outFolder !== 'string' && typeof outFolder !== 'function') {
@@ -27,7 +25,6 @@ function dest(outFolder, opt) {
   }
 
   var cwd = path.resolve(options.cwd);
-  var defaultMode = (options.mode || processMode);
 
   function saveFile (file, enc, cb) {
     var basePath;
@@ -42,13 +39,13 @@ function dest(outFolder, opt) {
 
     // wire up new properties
     file.stat = file.stat ? file.stat : new fs.Stats();
-    file.stat.mode = (options.mode || file.stat.mode || processMode);
+    file.stat.mode = (options.mode || file.stat.mode);
     file.cwd = cwd;
     file.base = basePath;
     file.path = writePath;
 
     // mkdirp the folder the file is going in
-    mkdirp(writeFolder, defaultMode, function(err){
+    mkdirp(writeFolder, function(err){
       if (err) {
         return cb(err);
       }

--- a/test/dest.js
+++ b/test/dest.js
@@ -370,6 +370,76 @@ describe('dest stream', function() {
     stream1.end();
   });
 
+  it('should write new files with the default user mode', function(done) {
+    var inputPath = path.join(__dirname, './fixtures/test.coffee');
+    var inputBase = path.join(__dirname, './fixtures/');
+    var expectedPath = path.join(__dirname, './out-fixtures/test.coffee');
+    var expectedContents = fs.readFileSync(inputPath);
+    var expectedCwd = __dirname;
+    var expectedBase = path.join(__dirname, './out-fixtures');
+    var expectedMode = 0666 & (~process.umask());
+
+    var expectedFile = new File({
+      base: inputBase,
+      cwd: __dirname,
+      path: inputPath,
+      contents: expectedContents,
+    });
+
+    var onEnd = function(){
+      buffered.length.should.equal(1);
+      buffered[0].should.equal(expectedFile);
+      fs.existsSync(expectedPath).should.equal(true);
+      realMode(fs.lstatSync(expectedPath).mode).should.equal(expectedMode);
+      done();
+    };
+
+    chmodSpy.reset();
+    var stream = vfs.dest('./out-fixtures/', {cwd: __dirname});
+
+    var buffered = [];
+    bufferStream = through.obj(dataWrap(buffered.push.bind(buffered)), onEnd);
+
+    stream.pipe(bufferStream);
+    stream.write(expectedFile);
+    stream.end();
+  });
+
+  it('should write new files with the specified mode', function(done) {
+    var inputPath = path.join(__dirname, './fixtures/test.coffee');
+    var inputBase = path.join(__dirname, './fixtures/');
+    var expectedPath = path.join(__dirname, './out-fixtures/test.coffee');
+    var expectedContents = fs.readFileSync(inputPath);
+    var expectedCwd = __dirname;
+    var expectedBase = path.join(__dirname, './out-fixtures');
+    var expectedMode = 0744;
+
+    var expectedFile = new File({
+      base: inputBase,
+      cwd: __dirname,
+      path: inputPath,
+      contents: expectedContents,
+    });
+
+    var onEnd = function(){
+      buffered.length.should.equal(1);
+      buffered[0].should.equal(expectedFile);
+      fs.existsSync(expectedPath).should.equal(true);
+      realMode(fs.lstatSync(expectedPath).mode).should.equal(expectedMode);
+      done();
+    };
+
+    chmodSpy.reset();
+    var stream = vfs.dest('./out-fixtures/', {cwd: __dirname, mode:expectedMode});
+
+    var buffered = [];
+    bufferStream = through.obj(dataWrap(buffered.push.bind(buffered)), onEnd);
+
+    stream.pipe(bufferStream);
+    stream.write(expectedFile);
+    stream.end();
+  });
+
   it('should update file mode to match the vinyl mode', function(done) {
     var inputPath = path.join(__dirname, './fixtures/test.coffee');
     var inputBase = path.join(__dirname, './fixtures/');


### PR DESCRIPTION
Discussed in #35 
Basically let nodejs do the right thing by letting "mode" be undefined if not set in the options or an existing mode on the vinyl.
