### PR TITLE
feat(fs): Add optional config to follow symlinks fully

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ build
 .idea
 sandbox
 coverage
+.tmp

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ fs.src(['./js/**/*.js', '!./js/vendor/*.js'])
     - Default value is `true`
     - `false` will disable writing the file to disk via `.dest()`
   - since - `Date` or `number` if you only want files that have been modified since the time specified.
+  - followSymlink - `true` or `false` if you want to follow symlinks fully
+    - Default value is `false`
   - Any glob-related options are documented in [glob-stream] and [node-glob]
 - Returns a Readable/Writable stream.
 - On write the stream will simply pass items through.

--- a/lib/src/getStats.js
+++ b/lib/src/getStats.js
@@ -3,17 +3,20 @@
 var through2 = require('through2');
 var fs = require('graceful-fs');
 
-function getStats() {
-  return through2.obj(fetchStats);
+function getStats(options) {
+  return through2.obj(fetchStats(options));
 }
 
-function fetchStats(file, enc, cb) {
-  fs.lstat(file.path, function (err, stat) {
-    if (stat) {
-      file.stat = stat;
-    }
-    cb(err, file);
-  });
+function fetchStats(options) {
+  var statMethod = (options && options.followSymlink) ? fs.lstat : fs.stat;
+  return function (file, enc, cb) {
+    statMethod(file.path, function (err, stat) {
+      if (stat) {
+        file.stat = stat;
+      }
+      cb(err, file);
+    });
+  };
 }
 
 module.exports = getStats;


### PR DESCRIPTION
- Add ability to pass optional parameter to use `fs.stat` instead of
  `fs.lstat`
- Add documentation
