### PR TITLE
remove engineStrict from the package.json - fixes #91

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   "engines": {
     "node": ">= 0.10"
   },
-  "engineStrict": true,
   "licenses": [
     {
       "type": "MIT",


### PR DESCRIPTION
This won't merge but I don't think this should be rebased.  Instead, it can just be tagged as a new version and not exist in the master branch.  However, I don't have commit access on this repo to complete this.  @contra can you add me?