### PR TITLE
sending options to throughjs via viny-js dest() 

### DIFF
--- a/lib/dest/index.js
+++ b/lib/dest/index.js
@@ -52,7 +52,7 @@ function dest(outFolder, opt) {
     });
   }
 
-  var stream = through2.obj(saveFile);
+  var stream = through2.obj(options,saveFile);
   // TODO: option for either backpressure or lossy
   stream.resume();
   return stream;

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   "engines": {
     "node": ">= 0.10"
   },
-  "engineStrict": true,
   "licenses": [
     {
       "type": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vinyl-fs",
   "description": "Vinyl adapter for the file system",
-  "version": "0.3.13",
+  "version": "0.3.14",
   "homepage": "http://github.com/wearefractal/vinyl-fs",
   "repository": "git://github.com/wearefractal/vinyl-fs.git",
   "author": "Fractal <contact@wearefractal.com> (http://wearefractal.com/)",


### PR DESCRIPTION
for sending options like "**highWaterMark**"(imp to specify buffer length) to throughtjs via vinyl-js dest()

**Issue**: Default highWaterMark value is 16(max buffer length), when default buffer length exceeds all files are not copied by dest