### PR TITLE
Sending options to through2 via dest()

### DIFF
--- a/lib/dest/index.js
+++ b/lib/dest/index.js
@@ -20,7 +20,7 @@ function dest(outFolder, opt) {
     });
   }
 
-  var saveStream = through2.obj(saveFile);
+  var saveStream = through2.obj(opt, saveFile);
   if (!opt.sourcemaps) {
     return saveStream;
   }


### PR DESCRIPTION
Ability to send options to through2.
Issue: default value set for `highWaterMark` in through2 is 16(max buffer length), when buffer length exceeds this defalut limit all files are not written to destination.