### PR TITLE
Check if `atime` Date object is invalid and set a new one explicitly

### DIFF
--- a/lib/utimes.js
+++ b/lib/utimes.js
@@ -8,14 +8,20 @@ function validDate(date) {
 }
 
 function utimes(writePath, stat, cb) {
+  // Given `mtime` is not valid, do nothing
   var mtime = stat.mtime;
-  var atime = stat.atime || new Date();
-
-  if (validDate(mtime) && validDate(atime)) {
-    return fs.utimes(writePath, atime, mtime, cb);
+  if (!validDate(mtime)) {
+    return cb();
   }
 
-  cb();
+  // Given `atime` is not valid, assign a new one with current time
+  var atime = stat.atime;
+  if (!validDate(atime)) {
+    atime = new Date();
+  }
+
+  // Set file `atime` and `mtime` fields
+  fs.utimes(writePath, atime, mtime, cb);
 }
 
 module.exports = utimes;


### PR DESCRIPTION
This fixes issue #118 