### PR TITLE
Fix file descriptor exhaustion when streaming many files

### DIFF
--- a/lib/src/getContents/streamFile.js
+++ b/lib/src/getContents/streamFile.js
@@ -2,9 +2,14 @@
 
 var fs = require('graceful-fs');
 var stripBom = require('strip-bom-stream');
+var lazystream = require('lazystream');
 
 function streamFile(file, opt, cb) {
-  file.contents = fs.createReadStream(file.path);
+  var filePath = file.path;
+
+  file.contents = new lazystream.Readable(function() {
+    return fs.createReadStream(filePath);
+  });
 
   if (opt.stripBOM) {
     file.contents = file.contents.pipe(stripBom());

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "graceful-fs": "^4.0.0",
     "gulp-sourcemaps": "^1.5.2",
     "is-valid-glob": "^0.3.0",
+    "lazystream": "^1.0.0",
     "merge-stream": "^1.0.0",
     "mkdirp": "^0.5.0",
     "object-assign": "^4.0.0",

--- a/test/dest.js
+++ b/test/dest.js
@@ -19,6 +19,7 @@ var should = require('should');
 require('mocha');
 
 var wipeOut = function() {
+  this.timeout(20000);
   spies.setError('false');
   statSpy.reset();
   chmodSpy.reset();


### PR DESCRIPTION
It appears as though streamFile was creating duplicate ReadStreams,
which somehow was causing the process to never free WriteStreams. Also
I've changed the removeListeners calls to unlisten to `complete` rather
than `cb`, since they're never told to listen to `cb` in the first
place.

I suspect this is related to #56 ?