### PR TITLE
Re-add stream resume in dest

### DIFF
--- a/lib/dest/index.js
+++ b/lib/dest/index.js
@@ -21,6 +21,8 @@ function dest(outFolder, opt) {
   }
 
   var saveStream = through2.obj(saveFile);
+  saveStream.resume();
+
   if (!opt.sourcemaps) {
     return saveStream;
   }


### PR DESCRIPTION
It appears as though stream.resume() was removed in commit 99db7de8f0,
this causes streams to prematurely end unless dest() is followed by
something providing a stream drain.

This change re-adds stream.resume(), causing dest() to consume the
entire incoming stream regardless.

I believe this fixes issue #120