### PR TITLE
#129 - Update documentation to more clearly explain what happens for default base option values.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ fs.src(['*.js', '!b*.js'])
     - Default is `process.cwd()`.
 
   - base - Specify the folder relative to the cwd. This is used to determine the file names when saving in `.dest()`.
-    - Default is where the glob begins if any.
-    - Default is `process.cwd()` if there is no glob.
+    - Default is where the glob begins, if any. For example, `path/to/**/*.js` would resolve to `path/to`.
+    - If there is no glob (i.e. a file path with no pattern), then the dirname of the path is used. For example, `path/to/some/file.js` would resolve to `path/to/some`.
 
   - buffer - `true` or `false` if you want to buffer the file.
     - Default value is `true`.


### PR DESCRIPTION
After discussing it with @phated in #129, it seems to me that the previous description of the default `base` value is incorrect in the docs. I was originally unsure where the source of truth was (docs or code) but it seems that the code is correct.