### PR TITLE
fix TypeError when the dest sourcemaps option is a boolean

### DIFF
--- a/lib/dest/index.js
+++ b/lib/dest/index.js
@@ -25,7 +25,12 @@ function dest(outFolder, opt) {
     return saveStream;
   }
 
-  var mapStream = sourcemaps.write(opt.sourcemaps.path, opt.sourcemaps);
+  var sourcemapOpt = opt.sourcemaps;
+  if (typeof sourcemapOpt === 'boolean') {
+    sourcemapOpt = { sourcemaps: sourcemapOpt };
+  }
+
+  var mapStream = sourcemaps.write(sourcemapOpt.path, sourcemapOpt);
   var outputStream = duplexify.obj(mapStream, saveStream);
   mapStream.pipe(saveStream);
 

--- a/test/dest.js
+++ b/test/dest.js
@@ -61,6 +61,31 @@ describe('dest stream', function() {
     }
   });
 
+  it('should not explode if the sourcemap option is true', function(done) {
+    var inputPath = path.join(__dirname, './fixtures/test.coffee');
+
+    var expectedFile = new File({
+      base: __dirname,
+      cwd: __dirname,
+      path: inputPath,
+      contents: null
+    });
+
+    var onEnd = function(){
+      buffered.length.should.equal(1);
+      buffered[0].should.equal(expectedFile);
+      done();
+    };
+
+    var stream = vfs.dest(path.join(__dirname, './out-fixtures/'), { sourcemaps: true });
+
+    var buffered = [];
+    var bufferStream = through.obj(dataWrap(buffered.push.bind(buffered)), onEnd);
+    stream.pipe(bufferStream);
+    stream.write(expectedFile);
+    stream.end();
+  });
+
   it('should pass through writes with cwd', function(done) {
     var inputPath = path.join(__dirname, './fixtures/test.coffee');
 


### PR DESCRIPTION
This PR fixes a TypeError that's thrown when a boolean `sourcemaps` option is passed to `dest` e.g.:

```javascript
fs.dest(dir, { sourcemaps: true })
```

### test.js

```javascript
'use strict'

let coffee = require('gulp-coffee')
let fs     = require('vinyl-fs')
let rename = require('gulp-rename')

fs.src('./input.coffee', { sourcemaps: true })
    .pipe(coffee({ sourceMap: true }))
    .pipe(rename('output.js'))
    .pipe(fs.dest('.', { sourcemaps: true }))
```

### input.coffee

```coffeescript
console.log 'Hello, world!'
```

    $ node ./test.js

### output

```
test/node_modules/gulp-sourcemaps/index.js:144
    options.includeContent = true;
                           ^

TypeError: Cannot assign to read only property 'includeContent' of true
  at Object.write (test/node_modules/gulp-sourcemaps/index.js:144:28)
  at Object.dest (test/node_modules/vinyl-fs/lib/dest/index.js:28:30)
  at Object.<anonymous> (test/test.js:10:14)
  at Module._compile (module.js:425:26)
  at Object.Module._extensions..js (module.js:432:10)
  at Module.load (module.js:356:32)
  at Function.Module._load (module.js:313:12)
  at Function.Module.runMain (module.js:457:10)
  at startup (node.js:138:18)
  at node.js:974:3
```
