### PR TITLE
Sink should respect a readable event on the destination stream

### DIFF
--- a/lib/sink.js
+++ b/lib/sink.js
@@ -11,6 +11,11 @@ function sink(stream) {
   });
 
   return function() {
+    // Respect readable listeners on the underlying stream
+    if (stream.listeners('readable').length > 0) {
+      return;
+    }
+
     stream.pipe(sinkStream);
   };
 }

--- a/test/dest.js
+++ b/test/dest.js
@@ -1337,6 +1337,29 @@ describe('dest stream', function() {
       .pipe(slowCountFiles);
   });
 
+  it('should respect readable listeners on destination stream', function(done) {
+    var srcPath = path.join(__dirname, './fixtures/test.coffee');
+    var srcStream = vfs.src(srcPath);
+    var destStream = vfs.dest('./out-fixtures/', { cwd: __dirname });
+
+    srcStream
+      .pipe(destStream);
+
+    var readables = 0;
+    destStream.on('readable', function() {
+      var data = destStream.read();
+
+      if (data == null) {
+        // Stream ended
+        readables.should.equal(1);
+        done();
+      } else {
+        // New data
+        readables++;
+      }
+    });
+  });
+
   it('should pass options to through2', function(done) {
     var srcPath = path.join(__dirname, './fixtures/test.coffee');
     var content = fs.readFileSync(srcPath);


### PR DESCRIPTION
Hello :smile: 

by using grunt-contrib-imagemin I encountered a problem that I tracked down to vinyl-fs 2.3.0. If one attaches a listener to the `readable` event of the `vinly-fs.dest` stream, the new sink (introduced in https://github.com/gulpjs/vinyl-fs/commit/df97b1482200e7bc5dd01a49f0bdedeed2b6bd08 ) prevents it from firing. I attached a test to this PR that hopefully explains the problem better.

The problem is that the `pipe()` call in `sink.js` turns the stream into flowing mode. In this mode the stream does no longer emit a `readable` event (see [Node docs](https://nodejs.org/docs/latest/api/stream.html#stream_class_stream_readable)).

This of course is a special case. Nevertheless the destination stream should not be turned into flowing mode if it's obvious that this was not intended. Imho that's the case if a developer adds a `readable` event listener, so I added a check for it.

Feedback is much appreciated! :smile: 

Ben