### PR TITLE
Don't pass `read` option from `src` to `through2`

### DIFF
--- a/lib/src/index.js
+++ b/lib/src/index.js
@@ -43,6 +43,10 @@ function src(glob, opt) {
     followSymlinks: true,
   }, opt);
 
+  // Don't pass `read` option on to through2
+  var read = options.read !== false;
+  options.read = undefined;
+
   var inputPass;
 
   if (!isValidGlob(glob)) {
@@ -54,20 +58,20 @@ function src(glob, opt) {
   var outputStream = globStream
     .pipe(normalizePath(options))
     .pipe(resolveSymlinks(options))
-    .pipe(through2.obj(opt, createFile));
+    .pipe(through2.obj(options, createFile));
 
   if (options.since != null) {
     outputStream = outputStream
       .pipe(filterSince(options.since));
   }
 
-  if (options.read !== false) {
+  if (read) {
     outputStream = outputStream
       .pipe(getContents(options));
   }
 
   if (options.passthrough === true) {
-    inputPass = through2.obj(opt);
+    inputPass = through2.obj(options);
     outputStream = duplexify.obj(inputPass, merge(outputStream, inputPass));
   }
   if (options.sourcemaps === true) {

--- a/test/src.js
+++ b/test/src.js
@@ -396,6 +396,27 @@ describe('source stream', function() {
     stream1.pipe(stream2).pipe(bufferStream);
   });
 
+  it('should not pass options.read on to through2', function(done) {
+    // Note: https://github.com/gulpjs/vinyl-fs/issues/153
+    // In future, if/when function values are supported for options like
+    // `read` and `buffered`, the expected value here will be 1.
+    var canary = 0;
+    var expected = 0;
+    var read = function() {
+      canary++;
+      return 0;
+    };
+
+    var onEnd = function() {
+      canary.should.equal(expected);
+      done();
+    };
+
+    var buffered = [];
+    var stream = vfs.src('./fixtures/test.coffee', { cwd: __dirname, read: read });
+    var bufferStream = through.obj(dataWrap(buffered.push.bind(buffered)), onEnd);
+    stream.pipe(bufferStream);
+  });
 });
 
 describe('.src() symlinks', function() {


### PR DESCRIPTION
As promised in [#153](https://github.com/gulpjs/vinyl-fs/issues/153)