### PR TITLE
Make tests aware of umask, and use octal strings for expected results

### DIFF
--- a/test/dest-modes.js
+++ b/test/dest-modes.js
@@ -48,7 +48,7 @@ describe('.dest() with custom modes', function() {
     var inputBase = path.join(__dirname, './fixtures/');
     var expectedPath = path.join(__dirname, './out-fixtures/test.coffee');
     var expectedContents = fs.readFileSync(inputPath);
-    var expectedMode = parseInt('655', 8);
+    var expectedMode = parseInt('677', 8) & ~process.umask();
 
     var expectedFile = new File({
       base: inputBase,
@@ -61,7 +61,7 @@ describe('.dest() with custom modes', function() {
     });
 
     var onEnd = function() {
-      expect(masked(fs.lstatSync(expectedPath).mode)).toEqual(expectedMode);
+      expect(masked(fs.lstatSync(expectedPath).mode).toString(8)).toEqual(expectedMode.toString(8));
       done();
     };
 
@@ -83,7 +83,7 @@ describe('.dest() with custom modes', function() {
     var inputBase = path.join(__dirname, './fixtures/');
     var expectedPath = path.join(__dirname, './out-fixtures/test.coffee');
     var expectedContents = fs.readFileSync(inputPath);
-    var expectedMode = parseInt('1655', 8);
+    var expectedMode = parseInt('1677', 8) & ~process.umask();
 
     var contentStream = through.obj();
     var expectedFile = new File({
@@ -97,7 +97,7 @@ describe('.dest() with custom modes', function() {
     });
 
     var onEnd = function() {
-      expect(masked(fs.lstatSync(expectedPath).mode)).toEqual(expectedMode);
+      expect(masked(fs.lstatSync(expectedPath).mode).toString(8)).toEqual(expectedMode.toString(8));
       done();
     };
 
@@ -121,7 +121,7 @@ describe('.dest() with custom modes', function() {
     var inputBase = path.join(__dirname, './fixtures/');
     var expectedPath = path.join(__dirname, './out-fixtures/test.coffee');
     var expectedContents = fs.readFileSync(inputPath);
-    var expectedMode = parseInt('655', 8);
+    var expectedMode = parseInt('677', 8) & ~process.umask();
 
     var contentStream = through.obj();
     var expectedFile = new File({
@@ -135,7 +135,7 @@ describe('.dest() with custom modes', function() {
     });
 
     var onEnd = function() {
-      expect(masked(fs.lstatSync(expectedPath).mode)).toEqual(expectedMode);
+      expect(masked(fs.lstatSync(expectedPath).mode).toString(8)).toEqual(expectedMode.toString(8));
       done();
     };
 
@@ -158,7 +158,7 @@ describe('.dest() with custom modes', function() {
     var inputPath = path.join(__dirname, './fixtures/test');
     var inputBase = path.join(__dirname, './fixtures/');
     var expectedPath = path.join(__dirname, './out-fixtures/test');
-    var expectedMode = parseInt('655', 8);
+    var expectedMode = parseInt('677', 8) & ~process.umask();
 
     var expectedFile = new File({
       base: inputBase,
@@ -174,7 +174,7 @@ describe('.dest() with custom modes', function() {
     });
 
     var onEnd = function() {
-      expect(masked(fs.lstatSync(expectedPath).mode)).toEqual(expectedMode);
+      expect(masked(fs.lstatSync(expectedPath).mode).toString(8)).toEqual(expectedMode.toString(8));
       done();
     };
 
@@ -193,7 +193,7 @@ describe('.dest() with custom modes', function() {
     var inputPath = path.join(__dirname, './fixtures/test');
     var inputBase = path.join(__dirname, './fixtures/');
     var expectedPath = path.join(__dirname, './out-fixtures/test');
-    var expectedMode = parseInt('1655', 8);
+    var expectedMode = parseInt('1677', 8) & ~process.umask();
 
     var expectedFile = new File({
       base: inputBase,
@@ -209,7 +209,7 @@ describe('.dest() with custom modes', function() {
     });
 
     var onEnd = function() {
-      expect(masked(fs.lstatSync(expectedPath).mode)).toEqual(expectedMode);
+      expect(masked(fs.lstatSync(expectedPath).mode).toString(8)).toEqual(expectedMode.toString(8));
       done();
     };
 
@@ -229,7 +229,7 @@ describe('.dest() with custom modes', function() {
     var inputBase = path.join(__dirname, './fixtures/');
     var expectedPath = path.join(__dirname, './out-fixtures/test.coffee');
     var expectedContents = fs.readFileSync(inputPath);
-    var expectedMode = parseInt('744', 8);
+    var expectedMode = parseInt('777', 8) & ~process.umask();
 
     var expectedFile = new File({
       base: inputBase,
@@ -239,7 +239,7 @@ describe('.dest() with custom modes', function() {
     });
 
     var onEnd = function() {
-      expect(masked(fs.lstatSync(expectedPath).mode)).toEqual(expectedMode);
+      expect(masked(fs.lstatSync(expectedPath).mode).toString(8)).toEqual(expectedMode.toString(8));
       done();
     };
 
@@ -260,8 +260,8 @@ describe('.dest() with custom modes', function() {
     var expectedPath = path.join(__dirname, './out-fixtures/test.coffee');
     var expectedContents = fs.readFileSync(inputPath);
     var expectedBase = path.join(__dirname, './out-fixtures');
-    var startMode = parseInt('0655', 8);
-    var expectedMode = parseInt('0722', 8);
+    var startMode = parseInt('655', 8);
+    var expectedMode = parseInt('722', 8);
 
     var expectedFile = new File({
       base: inputBase,
@@ -274,7 +274,7 @@ describe('.dest() with custom modes', function() {
     });
 
     var onEnd = function() {
-      expect(masked(fs.lstatSync(expectedPath).mode)).toEqual(expectedMode);
+      expect(masked(fs.lstatSync(expectedPath).mode).toString(8)).toEqual(expectedMode.toString(8));
       done();
     };
 
@@ -312,7 +312,7 @@ describe('.dest() with custom modes', function() {
     expectedFile.stat.mode = (startMode & ~parseInt('7777', 8)) | expectedMode;
 
     var onEnd = function() {
-      expect(masked(fs.lstatSync(expectedPath).mode)).toEqual(expectedMode);
+      expect(masked(fs.lstatSync(expectedPath).mode).toString(8)).toEqual(expectedMode.toString(8));
       done();
     };
 
@@ -337,8 +337,8 @@ describe('.dest() with custom modes', function() {
     var expectedBase = path.join(__dirname, './out-fixtures/wow');
     var expectedPath = path.join(__dirname, './out-fixtures/wow/suchempty');
     // NOTE: Darwin does not set setgid
-    var expectedDirMode = isDarwin ? parseInt('755', 8) : parseInt('2755', 8);
-    var expectedFileMode = parseInt('655', 8);
+    var expectedDirMode = (isDarwin ? parseInt('777', 8) : parseInt('2777', 8)) & ~process.umask();
+    var expectedFileMode = parseInt('677', 8) & ~process.umask();
 
     var firstFile = new File({
       base: inputBase,
@@ -349,8 +349,8 @@ describe('.dest() with custom modes', function() {
     });
 
     var onEnd = function() {
-      expect(masked(fs.lstatSync(expectedBase).mode)).toEqual(expectedDirMode);
-      expect(masked(fs.lstatSync(expectedPath).mode)).toEqual(expectedFileMode);
+      expect(masked(fs.lstatSync(expectedBase).mode).toString(8)).toEqual(expectedDirMode.toString(8));
+      expect(masked(fs.lstatSync(expectedPath).mode).toString(8)).toEqual(expectedFileMode.toString(8));
       done();
     };
 
@@ -376,7 +376,7 @@ describe('.dest() with custom modes', function() {
     var inputBase = path.join(__dirname, './fixtures/');
     var expectedPath = path.join(__dirname, './out-fixtures/test.coffee');
     var expectedContents = fs.readFileSync(inputPath);
-    var expectedMode = parseInt('711', 8);
+    var expectedMode = parseInt('777', 8)  & ~process.umask();
 
     var expectedFile = new File({
       base: inputBase,
@@ -390,7 +390,7 @@ describe('.dest() with custom modes', function() {
 
     var onEnd = function() {
       expect(fchmodSpy.calls.length).toEqual(0);
-      expect(masked(fs.lstatSync(expectedPath).mode)).toEqual(expectedMode);
+      expect(masked(fs.lstatSync(expectedPath).mode).toString(8)).toEqual(expectedMode.toString(8));
       done();
     };
 

--- a/test/dest.js
+++ b/test/dest.js
@@ -499,7 +499,7 @@ describe('dest stream', function() {
       buffered.length.should.equal(1);
       buffered[0].should.equal(expectedFile);
       fs.existsSync(expectedPath).should.equal(true);
-      realMode(fs.lstatSync(expectedPath).mode).should.equal(expectedMode);
+      realMode(fs.lstatSync(expectedPath).mode).toString(8).should.equal(expectedMode.toString(8));
       done();
     };
 

--- a/test/file-operations.js
+++ b/test/file-operations.js
@@ -132,7 +132,7 @@ describe('getModeDiff', function() {
 
     var result = getModeDiff(fsMode, vfsMode);
 
-    expect(result).toEqual(0);
+    expect(result.toString(8)).toEqual('0');
 
     done();
   });
@@ -143,7 +143,7 @@ describe('getModeDiff', function() {
 
     var result = getModeDiff(fsMode, vfsMode);
 
-    expect(result).toEqual(0);
+    expect(result.toString(8)).toEqual('0');
 
     done();
   });
@@ -154,7 +154,7 @@ describe('getModeDiff', function() {
 
     var result = getModeDiff(fsMode, vfsMode);
 
-    expect(result).toEqual(27);
+    expect(result.toString(8)).toEqual('33');
 
     done();
   });
@@ -165,7 +165,7 @@ describe('getModeDiff', function() {
 
     var result = getModeDiff(fsMode, vfsMode);
 
-    expect(result).toEqual(82);
+    expect(result.toString(8)).toEqual('122');
 
     done();
   });
@@ -176,7 +176,7 @@ describe('getModeDiff', function() {
 
     var result = getModeDiff(fsMode, vfsMode);
 
-    expect(result).toEqual(fsMode ^ vfsMode);
+    expect(result.toString(8)).toEqual('5000');
 
     done();
   });

--- a/test/symlink.js
+++ b/test/symlink.js
@@ -189,7 +189,7 @@ describe('symlink stream', function() {
     var expectedPath = path.join(__dirname, './out-fixtures/test.coffee');
     var expectedContents = fs.readFileSync(inputPath);
     var expectedBase = path.join(__dirname, './out-fixtures');
-    var expectedMode = parseInt('655', 8);
+    var expectedMode = parseInt('677', 8)  & ~process.umask();
 
     var expectedFile = new File({
       base: inputBase,
@@ -229,7 +229,7 @@ describe('symlink stream', function() {
     var expectedPath = path.join(__dirname, './out-fixtures/test.coffee');
     var expectedContents = fs.readFileSync(inputPath);
     var expectedBase = path.join(__dirname, './out-fixtures');
-    var expectedMode = parseInt('655', 8);
+    var expectedMode = parseInt('677', 8) & ~process.umask();
 
     var contentStream = through.obj();
     var expectedFile = new File({
@@ -273,7 +273,7 @@ describe('symlink stream', function() {
     var inputBase = path.join(__dirname, './fixtures/');
     var expectedPath = path.join(__dirname, './out-fixtures/wow');
     var expectedBase = path.join(__dirname, './out-fixtures');
-    var expectedMode = parseInt('655', 8);
+    var expectedMode = parseInt('677', 8) & ~process.umask();
 
     var expectedFile = new File({
       base: inputBase,
@@ -320,8 +320,8 @@ describe('symlink stream', function() {
     var inputBase = path.join(__dirname, './fixtures');
     var inputPath = path.join(__dirname, './fixtures/wow/suchempty');
     var expectedBase = path.join(__dirname, './out-fixtures/wow');
-    var expectedDirMode = parseInt('755', 8);
-    var expectedFileMode = parseInt('655', 8);
+    var expectedDirMode = parseInt('777', 8) & ~process.umask();
+    var expectedFileMode = parseInt('677', 8) & ~process.umask();
 
     var firstFile = new File({
       base: inputBase,
@@ -333,8 +333,8 @@ describe('symlink stream', function() {
     var buffered = [];
 
     var onEnd = function() {
-      realMode(fs.lstatSync(expectedBase).mode).should.equal(expectedDirMode);
-      realMode(buffered[0].stat.mode).should.equal(expectedFileMode);
+      realMode(fs.lstatSync(expectedBase).mode).toString(8).should.equal(expectedDirMode.toString(8));
+      realMode(buffered[0].stat.mode).toString(8).should.equal(expectedFileMode.toString(8));
       done();
     };
 


### PR DESCRIPTION
I think this fixes [#166](https://github.com/gulpjs/vinyl-fs/issues/166), and also has the tests use octal strings for expected results (easier to troubleshoot mode issues).