### PR TITLE
Correct `dot` option in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Type: `Boolean`
 
 Default: `true`
 
-##### `options.dots`
+##### `options.dot`
 
 Whether or not you want globs to match on dot files or not (e.g. `.gitignore`)
 


### PR DESCRIPTION
The option to include dot files is `options.dot` rather than `options.dots`. See the [documentation for node-glob](https://github.com/isaacs/node-glob/blob/68f2509d237babec64cf03adf72531127fd80339/README.md#options).