### PR TITLE
chore(followSymlinks): Rename to resolveSymlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Type: `Boolean`
 
 Default: `false`
 
-##### `options.followSymlinks`
+##### `options.resolveSymlinks`
 
 Whether or not to recursively resolve symlinks to their targets. Setting to `false` to preserve them as symlinks and make `file.symlink` equal the original symlink's target path.
 

--- a/lib/src/get-contents/index.js
+++ b/lib/src/get-contents/index.js
@@ -14,7 +14,7 @@ function getContents(opt) {
       return readDir(file, opt, onRead);
     }
 
-    // Process symbolic links included with `followSymlinks` option
+    // Process symbolic links included with `resolveSymlinks` option
     if (file.stat && file.stat.isSymbolicLink()) {
       return readSymbolicLink(file, opt, onRead);
     }

--- a/lib/src/index.js
+++ b/lib/src/index.js
@@ -29,7 +29,7 @@ function src(glob, opt) {
     stripBOM: koalas(boolean(opt.stripBOM), true),
     sourcemaps: koalas(boolean(opt.sourcemaps), false),
     passthrough: koalas(boolean(opt.passthrough), false),
-    followSymlinks: koalas(boolean(opt.followSymlinks), true),
+    resolveSymlinks: koalas(boolean(opt.resolveSymlinks), true),
   });
 
   // Don't pass `read` option on to through2

--- a/lib/src/wrap-with-vinyl-file.js
+++ b/lib/src/wrap-with-vinyl-file.js
@@ -17,7 +17,7 @@ function wrapWithVinylFile(options) {
 
       globFile.stat = stat;
 
-      if (!stat.isSymbolicLink() || !options.followSymlinks) {
+      if (!stat.isSymbolicLink() || !options.resolveSymlinks) {
         var vinylFile = new File(globFile);
         if (globFile.originalSymlinkPath) {
           // If we reach here, it means there is at least one

--- a/test/dest.js
+++ b/test/dest.js
@@ -582,7 +582,7 @@ describe('.dest()', function() {
       contents: null,
     });
 
-    // `src()` adds this side-effect with `followSymlinks` option set to false
+    // `src()` adds this side-effect with `resolveSymlinks` option set to false
     file.symlink = inputRelativeSymlinkPath;
 
     function assert(files) {

--- a/test/src-symlinks.js
+++ b/test/src-symlinks.js
@@ -75,7 +75,7 @@ describe('.src() with symlinks', function() {
     ], done);
   });
 
-  it('preserves file symlinks with followSymlinks option set to false', function(done) {
+  it('preserves file symlinks with resolveSymlinks option set to false', function(done) {
     var expectedRelativeSymlinkPath = fs.readlinkSync(symlinkPath);
 
     function assert(files) {
@@ -85,12 +85,12 @@ describe('.src() with symlinks', function() {
     }
 
     pipe([
-      vfs.src(symlinkPath, { followSymlinks: false }),
+      vfs.src(symlinkPath, { resolveSymlinks: false }),
       concat(assert),
     ], done);
   });
 
-  it('preserves directory symlinks with followSymlinks option set to false', function(done) {
+  it('preserves directory symlinks with resolveSymlinks option set to false', function(done) {
     var expectedRelativeSymlinkPath = fs.readlinkSync(symlinkDirpath);
 
     function assert(files) {
@@ -100,7 +100,7 @@ describe('.src() with symlinks', function() {
     }
 
     pipe([
-      vfs.src(symlinkDirpath, { followSymlinks: false }),
+      vfs.src(symlinkDirpath, { resolveSymlinks: false }),
       concat(assert),
     ], done);
   });


### PR DESCRIPTION
Not sure if I understood the issue, but this is an attempt to resolve #205 (assuming `resolveSymlinks` was the name that was landed on 😄  )