### PR TITLE
Fix #210 Windows symbolic links requiring admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,8 @@ Returns a stream that accepts [vinyl] `File` objects, create a symbolic link (i.
 __Note: The file will be modified after being written to this stream.__
   - `cwd`, `base`, and `path` will be overwritten to match the folder.
 
+__Note: On Windows, directory links are created using Junctions by default. Use the `useJunctions` option to disable this behavior.__
+
 #### Options
 
 - Values passed to the options must be of the right type, otherwise they will be ignored.
@@ -260,7 +262,15 @@ Whether or not the symlink should be relative or absolute.
 
 Type: `Boolean`
 
-Default: `false`.
+Default: `false`
+
+##### `options.useJunctions`
+
+Whether or not a directory symlink should be created as a `junction`.
+
+Type: `Boolean`
+
+Default: `true` on Windows, `false` on all other platforms
 
 ##### other
 

--- a/lib/dest/write-contents/write-stream.js
+++ b/lib/dest/write-contents/write-stream.js
@@ -41,7 +41,7 @@ function writeStream(file, onWritten) {
     file.contents.removeListener('error', onComplete);
 
     // TODO: this is doing sync stuff & the callback seems unnecessary
-    // TODO: do we really want to replace the contents stream or should we use a clone
+    // TODO: Replace the contents stream or use a clone?
     readStream(file, complete);
 
     function complete() {

--- a/lib/symlink/index.js
+++ b/lib/symlink/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var path = require('path');
+var os = require('os');
 
 var fs = require('graceful-fs');
 var through2 = require('through2');
@@ -12,6 +13,8 @@ var prepareWrite = require('../prepare-write');
 
 var boolean = valueOrFunction.boolean;
 
+var isWindows = (os.platform() === 'win32');
+
 function symlink(outFolder, opt) {
   if (!opt) {
     opt = {};
@@ -19,7 +22,24 @@ function symlink(outFolder, opt) {
 
   function linkFile(file, enc, callback) {
     var srcPath = file.path;
-    var symType = (file.isDirectory() ? 'dir' : 'file');
+
+    var isDirectory = file.isDirectory();
+
+    // This option provides a way to create a Junction instead of a
+    // Directory symlink on Windows. This comes with the following caveats:
+    // * NTFS Junctions cannot be relative.
+    // * NTFS Junctions MUST be directories.
+    // * NTFS Junctions must be on the same file system.
+    // * Most products CANNOT detect a directory is a Junction:
+    //    This has the side effect of possibly having a whole directory
+    //    deleted when a product is deleting the Junction directory.
+    //    For example, IntelliJ product lines will delete the entire
+    //    contents of the TARGET directory because the product does not
+    //    realize it's a symlink as the JVM and Node return false for isSymlink.
+    var useJunctions = koalas(boolean(opt.useJunctions, file), (isWindows && isDirectory));
+
+    var symDirType =  useJunctions ? 'junction' : 'dir';
+    var symType = isDirectory ? symDirType : 'file';
     var isRelative = koalas(boolean(opt.relative, file), false);
 
     prepareWrite(outFolder, file, opt, onPrepare);
@@ -30,7 +50,7 @@ function symlink(outFolder, opt) {
       }
 
       // This is done inside prepareWrite to use the adjusted file.base property
-      if (isRelative) {
+      if (isRelative && !useJunctions) {
         srcPath = path.relative(file.base, srcPath);
       }
 


### PR DESCRIPTION
This is just a reference PR for #211 because I'm not sure if the original author has time to finish this up.

TODO:
* [x] Remove new `link` method
* [x] Remove the added `src` tests because they don't do anything
* [x] Change author of the commit to give original author credit
* [x] Documentation
* [x] Don't allow the `relative` option with junctions
* [x] Need test for `forceJunctionDir` (and rename `useJunctions`) - Support function