### PR TITLE
Check mode of not-owned.txt, avoid repeated notices

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ node_js:
   - '0.10'
 before_script:
   - find test -type d -exec chmod g+s {} \;
-  - sudo chown root test/fixtures/not-owned/
   - sudo chown root test/fixtures/not-owned/not-owned.txt
+  - sudo chmod 666 test/fixtures/not-owned/not-owned.txt
 after_script:
   - npm run coveralls


### PR DESCRIPTION
I don't remember why I closed a similar [PR](https://github.com/gulpjs/vinyl-fs/pull/198) earlier, but I ran into this again today (on Linux, changing owner to root was not enough to make the not-owned tests pass, had to change mode as well).

I'm not sure why it works on Travis, actually. Could be a umask difference, or something like that.

Shouldn't conflict with the prepare work, I expect.