### PR TITLE
Refactor symlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,14 @@ Type: `Number`
 
 Default: The process mode.
 
+##### `options.overwrite`
+
+Whether or not existing files with the same path should be overwritten. Can also be a function that takes in a file and returns `true` or `false`.
+
+Type: `Boolean` or `Function`
+
+Default: `true` (always overwrite existing files)
+
 ##### `options.relative`
 
 Whether or not the symlink should be relative or absolute.

--- a/lib/dest/write-contents/index.js
+++ b/lib/dest/write-contents/index.js
@@ -7,6 +7,8 @@ var writeStream = require('./write-stream');
 var writeBuffer = require('./write-buffer');
 var writeSymbolicLink = require('./write-symbolic-link');
 
+var fo = require('../../file-operations');
+
 function writeContents(opt) {
 
   function writeFile(file, enc, callback) {
@@ -38,26 +40,13 @@ function writeContents(opt) {
     // This is invoked by the various writeXxx modules when they've finished
     // writing the contents.
     function onWritten(writeErr) {
-      if (isErrorFatal(writeErr)) {
+      if (fo.isFatalOverwriteError(writeErr, file.flag)) {
         return callback(writeErr);
       }
 
       callback(null, file);
     }
 
-    function isErrorFatal(err) {
-      if (!err) {
-        return false;
-      }
-
-      if (err.code === 'EEXIST' && file.flag === 'wx') {
-        // Handle scenario for file overwrite failures.
-        return false;
-      }
-
-      // Otherwise, this is a fatal error
-      return true;
-    }
   }
 
   return through.obj(writeFile);

--- a/lib/dest/write-contents/write-symbolic-link.js
+++ b/lib/dest/write-contents/write-symbolic-link.js
@@ -2,19 +2,17 @@
 
 var fs = require('graceful-fs');
 
+var fo = require('../../file-operations');
+
 function writeSymbolicLink(file, onWritten) {
   // TODO handle symlinks properly
   fs.symlink(file.symlink, file.path, function(symlinkErr) {
-    if (isFatalError(symlinkErr)) {
+    if (fo.isFatalOverwriteError(symlinkErr)) {
       return onWritten(symlinkErr);
     }
 
     onWritten();
   });
-}
-
-function isFatalError(err) {
-  return (err && err.code !== 'EEXIST');
 }
 
 module.exports = writeSymbolicLink;

--- a/lib/file-operations.js
+++ b/lib/file-operations.js
@@ -40,6 +40,28 @@ function isValidUnixId(id) {
   return true;
 }
 
+function isFatalOverwriteError(err, flag) {
+  if (!err) {
+    return false;
+  }
+
+  if (err.code === 'EEXIST' && flag === 'wx') {
+    // Handle scenario for file overwrite failures.
+    return false;
+  }
+
+  // Otherwise, this is a fatal error
+  return true;
+}
+
+function isFatalUnlinkError(err) {
+  if (!err || err.code === 'ENOENT') {
+    return false;
+  }
+
+  return true;
+}
+
 function getModeDiff(fsMode, vinylMode) {
   var modeDiff = 0;
 
@@ -420,6 +442,8 @@ function cleanup(callback) {
 module.exports = {
   closeFd: closeFd,
   isValidUnixId: isValidUnixId,
+  isFatalOverwriteError: isFatalOverwriteError,
+  isFatalUnlinkError: isFatalUnlinkError,
   getModeDiff: getModeDiff,
   getTimesDiff: getTimesDiff,
   getOwnerDiff: getOwnerDiff,

--- a/lib/symlink/index.js
+++ b/lib/symlink/index.js
@@ -11,6 +11,7 @@ var valueOrFunction = require('value-or-function');
 var koalas = require('koalas');
 var lead = require('lead');
 
+var fo = require('../file-operations');
 var makeDirs = require('../dest/make-dirs');
 
 var boolean = valueOrFunction.boolean;
@@ -60,31 +61,17 @@ function symlink(outFolder, opt) {
     }
 
     function onUnlink(unlinkErr) {
-      if (unlinkErr && unlinkErr.code !== 'ENOENT') {
-        return callback(unlinkErr);;
+      if (fo.isFatalUnlinkError(unlinkErr)) {
+        return callback(unlinkErr);
       }
       fs.symlink(srcPath, file.path, symType, onSymlink);
     }
 
     function onSymlink(symlinkErr) {
-      if (isErrorFatal(symlinkErr)) {
+      if (fo.isFatalOverwriteError(symlinkErr, file.flag)) {
         return callback(symlinkErr);
       }
       callback(null, file);
-    }
-
-    function isErrorFatal(err) {
-      if (!err) {
-        return false;
-      }
-
-      if (err.code === 'EEXIST' && file.flag === 'wx') {
-        // Handle scenario for file overwrite failures.
-        return false;
-      }
-
-      // Otherwise, this is a fatal error
-      return true;
     }
   }
 

--- a/lib/symlink/index.js
+++ b/lib/symlink/index.js
@@ -36,7 +36,7 @@ function symlink(outFolder, opt) {
     // * Most products CANNOT detect a directory is a Junction:
     //    This has the side effect of possibly having a whole directory
     //    deleted when a product is deleting the Junction directory.
-    //    For example, IntelliJ product lines will delete the entire
+    //    For example, JetBrains product lines will delete the entire
     //    contents of the TARGET directory because the product does not
     //    realize it's a symlink as the JVM and Node return false for isSymlink.
     var useJunctions = koalas(boolean(opt.useJunctions, file), (isWindows && isDirectory));
@@ -50,13 +50,41 @@ function symlink(outFolder, opt) {
       srcPath = path.relative(file.base, srcPath);
     }
 
-    fs.symlink(srcPath, file.path, symType, onSymlink);
+    // Because fs.symlink does not allow atomic overwrite option with flags, we
+    // delete and recreate if the link already exists and overwrite is true.
+    if (file.flag === 'w') {
+      // TODO What happens when we call unlink with windows junctions?
+      fs.unlink(file.path, onUnlink);
+    } else {
+      fs.symlink(srcPath, file.path, symType, onSymlink);
+    }
+
+    function onUnlink(unlinkErr) {
+      if (unlinkErr && unlinkErr.code !== 'ENOENT') {
+        return callback(unlinkErr);;
+      }
+      fs.symlink(srcPath, file.path, symType, onSymlink);
+    }
 
     function onSymlink(symlinkErr) {
       if (isErrorFatal(symlinkErr)) {
         return callback(symlinkErr);
       }
       callback(null, file);
+    }
+
+    function isErrorFatal(err) {
+      if (!err) {
+        return false;
+      }
+
+      if (err.code === 'EEXIST' && file.flag === 'wx') {
+        // Handle scenario for file overwrite failures.
+        return false;
+      }
+
+      // Otherwise, this is a fatal error
+      return true;
     }
   }
 
@@ -68,21 +96,6 @@ function symlink(outFolder, opt) {
 
   // Sink the stream to start flowing
   return lead(stream);
-}
-
-function isErrorFatal(err) {
-  if (!err) {
-    return false;
-  }
-
-  // TODO: should we check file.flag like .dest()?
-  if (err.code === 'EEXIST') {
-    // Handle scenario for file overwrite failures.
-    return false;
-  }
-
-  // Otherwise, this is a fatal error
-  return true;
 }
 
 module.exports = symlink;

--- a/lib/symlink/index.js
+++ b/lib/symlink/index.js
@@ -11,9 +11,8 @@ var valueOrFunction = require('value-or-function');
 var koalas = require('koalas');
 var lead = require('lead');
 
-var fo = require('../file-operations');
+var makeDirs = require('../dest/make-dirs');
 
-var number = valueOrFunction.number;
 var boolean = valueOrFunction.boolean;
 
 var isWindows = (os.platform() === 'win32');
@@ -51,19 +50,7 @@ function symlink(outFolder, opt) {
       srcPath = path.relative(file.base, srcPath);
     }
 
-    // TODO: make DRY with .dest()
-    var dirMode = number(opt.dirMode, file);
-    var writeFolder = path.dirname(file.path);
-
-    fo.mkdirp(writeFolder, dirMode, onMkdirp);
-
-    function onMkdirp(mkdirpErr) {
-      if (mkdirpErr) {
-        return callback(mkdirpErr);
-      }
-
-      fs.symlink(srcPath, file.path, symType, onSymlink);
-    }
+    fs.symlink(srcPath, file.path, symType, onSymlink);
 
     function onSymlink(symlinkErr) {
       if (isErrorFatal(symlinkErr)) {
@@ -75,6 +62,7 @@ function symlink(outFolder, opt) {
 
   var stream = pumpify.obj(
     prepare.dest(outFolder, opt),
+    makeDirs(opt),
     through.obj(linkFile)
   );
 

--- a/test/file-operations.js
+++ b/test/file-operations.js
@@ -1473,8 +1473,8 @@ describe('createWriteStream', function() {
   });
 
   it('accepts flag option', function(done) {
-    // Write 12 stars then 12345 because the length of expected is 12
-    fs.writeFileSync(outputPath, '************12345');
+    // Write 13 stars then 12345 because the length of expected is 13
+    fs.writeFileSync(outputPath, '*************12345');
 
     function assert(err) {
       var outputContents = fs.readFileSync(outputPath, 'utf8');

--- a/test/file-operations.js
+++ b/test/file-operations.js
@@ -30,6 +30,8 @@ var getModeDiff = fo.getModeDiff;
 var getTimesDiff = fo.getTimesDiff;
 var getOwnerDiff = fo.getOwnerDiff;
 var isValidUnixId = fo.isValidUnixId;
+var isFatalOverwriteError = fo.isFatalOverwriteError;
+var isFatalUnlinkError = fo.isFatalUnlinkError;
 var updateMetadata = fo.updateMetadata;
 var createWriteStream = fo.createWriteStream;
 
@@ -168,6 +170,70 @@ describe('isValidUnixId', function() {
 
     done();
   });
+});
+
+describe('isFatalOverwriteError', function() {
+
+  it('returns false if not given any error', function(done) {
+    var result = isFatalOverwriteError(null);
+
+    expect(result).toEqual(false);
+
+    done();
+  });
+
+  it('returns true if code != EEXIST', function(done) {
+    var result = isFatalOverwriteError({ code: 'EOTHER' });
+
+    expect(result).toEqual(true);
+
+    done();
+  });
+
+  it('returns false if code == EEXIST and flag == wx', function(done) {
+    var result = isFatalOverwriteError({ code: 'EEXIST' }, 'wx');
+
+    expect(result).toEqual(false);
+
+    done();
+  });
+
+  it('returns true if error.code == EEXIST and file.flag != wx', function(done) {
+    var result = isFatalOverwriteError({ code: 'EEXIST' }, 'w');
+
+    expect(result).toEqual(true);
+
+    done();
+  });
+
+});
+
+describe('isFatalUnlinkError', function() {
+
+  it('returns false if not given any error', function(done) {
+    var result = isFatalUnlinkError(null);
+
+    expect(result).toEqual(false);
+
+    done();
+  });
+
+  it('returns false if code == ENOENT', function(done) {
+    var result = isFatalUnlinkError({ code: 'ENOENT' }, 'wx');
+
+    expect(result).toEqual(false);
+
+    done();
+  });
+
+  it('returns true if code != ENOENT', function(done) {
+    var result = isFatalUnlinkError({ code: 'EOTHER' });
+
+    expect(result).toEqual(true);
+
+    done();
+  });
+
 });
 
 describe('getModeDiff', function() {

--- a/test/symlink.js
+++ b/test/symlink.js
@@ -542,6 +542,124 @@ describe('symlink stream', function() {
     ], assert);
   });
 
+  it('does not overwrite links with overwrite option set to false', function(done) {
+    var existingContents = 'Lorem Ipsum';
+
+    var file = new File({
+      base: inputBase,
+      path: inputPath,
+      contents: null,
+    });
+
+    function assert(files) {
+      var outputContents = fs.readFileSync(outputPath, 'utf8');
+
+      expect(files.length).toEqual(1);
+      expect(outputContents).toEqual(existingContents);
+    }
+
+    // Write expected file which should not be overwritten
+    fs.mkdirSync(outputBase);
+    fs.writeFileSync(outputPath, existingContents);
+
+    pipe([
+      from.obj([file]),
+      vfs.symlink(outputBase, { overwrite: false }),
+      concat(assert),
+    ], done);
+  });
+
+  it('overwrites links with overwrite option set to true', function(done) {
+    var existingContents = 'Lorem Ipsum';
+
+    var file = new File({
+      base: inputBase,
+      path: inputPath,
+      contents: null,
+    });
+
+    function assert(files) {
+      var outputContents = fs.readFileSync(outputPath, 'utf8');
+
+      expect(files.length).toEqual(1);
+      expect(outputContents).toEqual(contents);
+    }
+
+    // This should be overwritten
+    fs.mkdirSync(outputBase);
+    fs.writeFileSync(outputPath, existingContents);
+
+    pipe([
+      from.obj([file]),
+      vfs.symlink(outputBase, { overwrite: true }),
+      concat(assert),
+    ], done);
+  });
+
+  it('does not overwrite links with overwrite option set to a function that returns false', function(done) {
+    var existingContents = 'Lorem Ipsum';
+
+    var file = new File({
+      base: inputBase,
+      path: inputPath,
+      contents: null,
+    });
+
+    function overwrite(f) {
+      expect(f).toEqual(file);
+      return false;
+    }
+
+    function assert(files) {
+      var outputContents = fs.readFileSync(outputPath, 'utf8');
+
+      expect(files.length).toEqual(1);
+      expect(outputContents).toEqual(existingContents);
+    }
+
+    // Write expected file which should not be overwritten
+    fs.mkdirSync(outputBase);
+    fs.writeFileSync(outputPath, existingContents);
+
+    pipe([
+      from.obj([file]),
+      vfs.symlink(outputBase, { overwrite: overwrite }),
+      concat(assert),
+    ], done);
+  });
+
+  it('overwrites links with overwrite option set to a function that returns true', function(done) {
+    var existingContents = 'Lorem Ipsum';
+
+    var file = new File({
+      base: inputBase,
+      path: inputPath,
+      contents: null,
+    });
+
+    function overwrite(f) {
+      expect(f).toEqual(file);
+      return true;
+    }
+
+    function assert(files) {
+      var outputContents = fs.readFileSync(outputPath, 'utf8');
+
+      expect(files.length).toEqual(1);
+      expect(outputContents).toEqual(contents);
+    }
+
+    // This should be overwritten
+    fs.mkdirSync(outputBase);
+    fs.writeFileSync(outputPath, existingContents);
+
+    pipe([
+      from.obj([file]),
+      vfs.symlink(outputBase, { overwrite: overwrite }),
+      concat(assert),
+    ], done);
+  });
+
   it('emits an end event', function(done) {
     var symlinkStream = vfs.symlink(outputBase);
 

--- a/test/utils/test-constants.js
+++ b/test/utils/test-constants.js
@@ -38,8 +38,8 @@ var symlinkMultiDirpathSecond = path.join(outputBase, './test-multi-layer-symlin
 var symlinkNestedFirst = path.join(outputBase, './test-multi-layer-symlink');
 var symlinkNestedSecond = path.join(outputBase, './foo/baz-link.txt');
 // Used for contents of files
-var contents = 'Hello World!';
-var sourcemapContents = '//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiLi9maXh0dXJlcyIsIm5hbWVzIjpbXSwibWFwcGluZ3MiOiIiLCJzb3VyY2VzIjpbIi4vZml4dHVyZXMiXSwic291cmNlc0NvbnRlbnQiOlsiSGVsbG8gV29ybGQhIl19';
+var contents = 'Hello World!\n';
+var sourcemapContents = '//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiLi9maXh0dXJlcyIsIm5hbWVzIjpbXSwibWFwcGluZ3MiOiIiLCJzb3VyY2VzIjpbIi4vZml4dHVyZXMiXSwic291cmNlc0NvbnRlbnQiOlsiSGVsbG8gV29ybGQhXG4iXX0=';
 
 module.exports = {
   inputRelative: inputRelative,


### PR DESCRIPTION
Tried to dry up the `symlink` stuff a bit, as per some TODOs, but stopped short of touching the interaction with vinyl-prepare (which I think @phated mentioned having worked on).

Notes:
- The first commit is unrelated but addresses a quirk I ran into whilst preparing the later ones.
- The `overwrite` logic for symlinks here does an `unlink` if the option is true, I'm not sure what that would do to junctions on Windows.
- Perhaps the last commit is actually Breaking.