### PR TITLE
reintroduce prepareWrite back ontop of the options changes

### DIFF
--- a/lib/dest/index.js
+++ b/lib/dest/index.js
@@ -1,23 +1,54 @@
 'use strict';
 
+var path = require('path');
+
 var lead = require('lead');
+var koalas = require('koalas');
 var pumpify = require('pumpify');
 var prepare = require('vinyl-prepare');
+var valueOrFunction = require('value-or-function');
 
 var fo = require('../file-operations');
+var options = require('../options');
 var sourcemap = require('./sourcemap');
 var writeContents = require('./write-contents');
+
+var number = valueOrFunction.number;
+var string = valueOrFunction.string;
+var boolean = valueOrFunction.boolean;
+var stringOrBool = valueOrFunction.bind(null, ['string', 'boolean']);
 
 function dest(outFolder, opt) {
   if (!opt) {
     opt = {};
   }
 
+  function resolveOptions(file) {
+    // Never re-use opts
+    var ourOpts = {};
+
+    ourOpts.sourcemaps = koalas(stringOrBool(opt.sourcemaps, file), false);
+    // TODO: Can this be put on file.stat?
+    // TODO: default mode?
+    ourOpts.dirMode = number(opt.dirMode, file);
+
+    // TODO: Take out of vinyl-prepare???
+    var defaultMode = file.stat ? file.stat.mode : null;
+    ourOpts.mode = koalas(number(opt.mode, file), defaultMode);
+    ourOpts.flag = koalas(boolean(opt.overwrite, file), true) ? 'w' : 'wx';
+    // TODO: maybe path.resolve in vinyl-prepare??
+    ourOpts.cwd = path.resolve(koalas(string(opt.cwd, file), process.cwd()));
+
+    return ourOpts;
+  }
+
   var saveStream = pumpify.obj(
+    options.attach(resolveOptions),
     prepare.dest(outFolder, opt),
-    sourcemap(opt),
-    fo.mkdirpStream(opt),
-    writeContents(opt)
+    sourcemap(),
+    fo.mkdirpStream(),
+    writeContents(),
+    options.unattach()
   );
 
   // Sink the output stream to start flowing

--- a/lib/dest/index.js
+++ b/lib/dest/index.js
@@ -1,15 +1,13 @@
 'use strict';
 
-var path = require('path');
-
 var lead = require('lead');
 var koalas = require('koalas');
 var pumpify = require('pumpify');
-var prepare = require('vinyl-prepare');
 var valueOrFunction = require('value-or-function');
 
 var fo = require('../file-operations');
 var options = require('../options');
+var prepareWrite = require('../prepare-write');
 var sourcemap = require('./sourcemap');
 var writeContents = require('./write-contents');
 
@@ -23,28 +21,33 @@ function dest(outFolder, opt) {
     opt = {};
   }
 
+  if (!outFolder) {
+    throw new Error('Invalid output folder');
+  }
+
   function resolveOptions(file) {
     // Never re-use opts
     var ourOpts = {};
+
+    // Not from opt
+    ourOpts.outFolder = string(outFolder, file);
 
     ourOpts.sourcemaps = koalas(stringOrBool(opt.sourcemaps, file), false);
     // TODO: Can this be put on file.stat?
     // TODO: default mode?
     ourOpts.dirMode = number(opt.dirMode, file);
 
-    // TODO: Take out of vinyl-prepare???
     var defaultMode = file.stat ? file.stat.mode : null;
     ourOpts.mode = koalas(number(opt.mode, file), defaultMode);
     ourOpts.flag = koalas(boolean(opt.overwrite, file), true) ? 'w' : 'wx';
-    // TODO: maybe path.resolve in vinyl-prepare??
-    ourOpts.cwd = path.resolve(koalas(string(opt.cwd, file), process.cwd()));
+    ourOpts.cwd = koalas(string(opt.cwd, file), process.cwd());
 
     return ourOpts;
   }
 
   var saveStream = pumpify.obj(
     options.attach(resolveOptions),
-    prepare.dest(outFolder, opt),
+    prepareWrite(),
     sourcemap(),
     fo.mkdirpStream(),
     writeContents(),

--- a/lib/dest/sourcemap.js
+++ b/lib/dest/sourcemap.js
@@ -2,22 +2,24 @@
 
 var through = require('through2');
 var sourcemap = require('vinyl-sourcemap');
-var valueOrFunction = require('value-or-function');
 
-var stringOrBool = valueOrFunction.bind(null, ['string', 'boolean']);
+var options = require('../options');
 
-function sourcemapStream(opt) {
+function sourcemapStream() {
 
   function saveSourcemap(file, enc, callback) {
     var self = this;
 
-    var srcMap = stringOrBool(opt.sourcemaps, file);
+    var sourcemapsOpt = options.get(file, 'sourcemaps');
 
-    if (!srcMap) {
+    if (!sourcemapsOpt) {
       return callback(null, file);
     }
 
-    var srcMapLocation = (typeof srcMap === 'string' ? srcMap : undefined);
+    var srcMapLocation;
+    if (typeof sourcemapsOpt === 'string') {
+      srcMapLocation = sourcemapsOpt;
+    }
 
     sourcemap.write(file, srcMapLocation, onWrite);
 

--- a/lib/dest/write-contents/index.js
+++ b/lib/dest/write-contents/index.js
@@ -8,6 +8,7 @@ var writeBuffer = require('./write-buffer');
 var writeSymbolicLink = require('./write-symbolic-link');
 
 var fo = require('../../file-operations');
+var options = require('../../options');
 
 function writeContents() {
 
@@ -40,7 +41,8 @@ function writeContents() {
     // This is invoked by the various writeXxx modules when they've finished
     // writing the contents.
     function onWritten(writeErr) {
-      if (fo.isFatalOverwriteError(writeErr, file.flag)) {
+      var flag = options.get(file, 'flag');
+      if (fo.isFatalOverwriteError(writeErr, flag)) {
         return callback(writeErr);
       }
 

--- a/lib/dest/write-contents/index.js
+++ b/lib/dest/write-contents/index.js
@@ -9,7 +9,7 @@ var writeSymbolicLink = require('./write-symbolic-link');
 
 var fo = require('../../file-operations');
 
-function writeContents(opt) {
+function writeContents() {
 
   function writeFile(file, enc, callback) {
     // If directory then mkdirp it

--- a/lib/dest/write-contents/write-buffer.js
+++ b/lib/dest/write-contents/write-buffer.js
@@ -1,11 +1,12 @@
 'use strict';
 
 var fo = require('../../file-operations');
+var options = require('../../options');
 
 function writeBuffer(file, onWritten) {
   var opt = {
     mode: file.stat.mode,
-    flag: file.flag,
+    flag: options.get(file, 'flag'),
   };
 
   fo.writeFile(file.path, file.contents, opt, onWriteFile);

--- a/lib/dest/write-contents/write-stream.js
+++ b/lib/dest/write-contents/write-stream.js
@@ -1,13 +1,14 @@
 'use strict';
 
 var fo = require('../../file-operations');
+var options = require('../../options');
 var readStream = require('../../src/read-contents/read-stream');
 
 function writeStream(file, onWritten) {
   var opt = {
     mode: file.stat.mode,
     // TODO: need to test this (node calls this `flags` property)
-    flag: file.flag,
+    flag: options.get(file, 'flag'),
   };
 
   // TODO: is this the best API?

--- a/lib/file-operations.js
+++ b/lib/file-operations.js
@@ -6,10 +6,10 @@ var fs = require('graceful-fs');
 var path = require('path');
 var assign = require('object-assign');
 var date = require('value-or-function').date;
-var number = require('value-or-function').number;
 var through = require('through2');
 var FlushWriteStream = require('flush-write-stream');
 
+var options = require('./options');
 var constants = require('./constants');
 
 var APPEND_MODE_REGEXP = /a/;
@@ -345,11 +345,11 @@ function mkdirp(dirpath, customMode, callback) {
   }
 }
 
-function mkdirpStream(opt) {
+function mkdirpStream() {
 
   function makeFileDirs(file, enc, callback) {
     // TODO: Can this be put on file.stat?
-    var dirMode = number(opt.dirMode, file);
+    var dirMode = options.get(file, 'dirMode');
 
     mkdirp(file.dirname, dirMode, onMkdirp);
 

--- a/lib/options.js
+++ b/lib/options.js
@@ -1,0 +1,47 @@
+'use strict';
+
+var WM = require('es6-weak-map');
+var through = require('through2');
+
+// WeakMap for storing options
+var options = new WM();
+
+function attach(fn) {
+
+  function attacher(file, enc, callback) {
+    var opts = fn(file);
+
+    options.set(file, opts);
+
+    callback(null, file);
+  }
+
+  return through.obj(attacher);
+}
+
+function unattach() {
+
+  function unattacher(file, enc, callback) {
+    options.delete(file);
+
+    callback(null, file);
+  }
+
+  return through.obj(unattacher);
+}
+
+function get(file, property) {
+  var opts = options.get(file);
+
+  if (!opts) {
+    return;
+  }
+
+  return opts[property];
+}
+
+module.exports = {
+  attach: attach,
+  unattach: unattach,
+  get: get,
+};

--- a/lib/prepare-write.js
+++ b/lib/prepare-write.js
@@ -1,0 +1,38 @@
+'use strict';
+
+var path = require('path');
+
+var fs = require('graceful-fs');
+var through = require('through2');
+
+var options = require('./options');
+
+function prepareWrite() {
+
+  function prepare(file, enc, cb) {
+    var mode = options.get(file, 'mode');
+    var cwd = options.get(file, 'cwd');
+
+    cwd = path.resolve(cwd);
+
+    var outFolderPath = options.get(file, 'outFolder');
+    if (!outFolderPath) {
+      return cb(new Error('Invalid output folder'));
+    }
+    var basePath = path.resolve(cwd, outFolderPath);
+    var writePath = path.resolve(basePath, file.relative);
+
+    // Wire up new properties
+    file.stat = (file.stat || new fs.Stats());
+    file.stat.mode = mode;
+    file.cwd = cwd;
+    file.base = basePath;
+    file.path = writePath;
+
+    cb(null, file);
+  }
+
+  return through.obj(prepare);
+}
+
+module.exports = prepareWrite;

--- a/lib/symlink/index.js
+++ b/lib/symlink/index.js
@@ -12,7 +12,10 @@ var koalas = require('koalas');
 var lead = require('lead');
 
 var fo = require('../file-operations');
+var options = require('../options');
 
+var number = valueOrFunction.number;
+var string = valueOrFunction.string;
 var boolean = valueOrFunction.boolean;
 
 var isWindows = (os.platform() === 'win32');
@@ -74,10 +77,30 @@ function symlink(outFolder, opt) {
     }
   }
 
+  function resolveOptions(file) {
+    // Never re-use opts
+    var ourOpts = {};
+
+    // TODO: Can this be put on file.stat?
+    // TODO: default mode?
+    ourOpts.dirMode = number(opt.dirMode, file);
+
+    // TODO: Take out of vinyl-prepare???
+    var defaultMode = file.stat ? file.stat.mode : null;
+    ourOpts.mode = koalas(number(opt.mode, file), defaultMode);
+    ourOpts.flag = koalas(boolean(opt.overwrite, file), true) ? 'w' : 'wx';
+    // TODO: maybe path.resolve in vinyl-prepare??
+    ourOpts.cwd = path.resolve(koalas(string(opt.cwd, file), process.cwd()));
+
+    return ourOpts;
+  }
+
   var stream = pumpify.obj(
+    options.attach(resolveOptions),
     prepare.dest(outFolder, opt),
-    fo.mkdirpStream(opt),
-    through.obj(linkFile)
+    fo.mkdirpStream(),
+    through.obj(linkFile),
+    options.unattach()
   );
 
   // Sink the stream to start flowing

--- a/lib/symlink/index.js
+++ b/lib/symlink/index.js
@@ -55,7 +55,8 @@ function symlink(outFolder, opt) {
 
     // Because fs.symlink does not allow atomic overwrite option with flags, we
     // delete and recreate if the link already exists and overwrite is true.
-    if (file.flag === 'w') {
+    var flag = options.get(file, 'flag');
+    if (flag === 'w') {
       // TODO What happens when we call unlink with windows junctions?
       fs.unlink(file.path, onUnlink);
     } else {
@@ -70,7 +71,7 @@ function symlink(outFolder, opt) {
     }
 
     function onSymlink(symlinkErr) {
-      if (fo.isFatalOverwriteError(symlinkErr, file.flag)) {
+      if (fo.isFatalOverwriteError(symlinkErr, flag)) {
         return callback(symlinkErr);
       }
       callback(null, file);

--- a/lib/symlink/index.js
+++ b/lib/symlink/index.js
@@ -6,13 +6,13 @@ var os = require('os');
 var fs = require('graceful-fs');
 var pumpify = require('pumpify');
 var through = require('through2');
-var prepare = require('vinyl-prepare');
 var valueOrFunction = require('value-or-function');
 var koalas = require('koalas');
 var lead = require('lead');
 
 var fo = require('../file-operations');
 var options = require('../options');
+var prepareWrite = require('../prepare-write');
 
 var number = valueOrFunction.number;
 var string = valueOrFunction.string;
@@ -82,15 +82,16 @@ function symlink(outFolder, opt) {
     // Never re-use opts
     var ourOpts = {};
 
+    // Not from opt
+    ourOpts.outFolder = string(outFolder, file);
+
     // TODO: Can this be put on file.stat?
     // TODO: default mode?
     ourOpts.dirMode = number(opt.dirMode, file);
 
-    // TODO: Take out of vinyl-prepare???
     var defaultMode = file.stat ? file.stat.mode : null;
     ourOpts.mode = koalas(number(opt.mode, file), defaultMode);
     ourOpts.flag = koalas(boolean(opt.overwrite, file), true) ? 'w' : 'wx';
-    // TODO: maybe path.resolve in vinyl-prepare??
     ourOpts.cwd = path.resolve(koalas(string(opt.cwd, file), process.cwd()));
 
     return ourOpts;
@@ -98,7 +99,7 @@ function symlink(outFolder, opt) {
 
   var stream = pumpify.obj(
     options.attach(resolveOptions),
-    prepare.dest(outFolder, opt),
+    prepareWrite(),
     fo.mkdirpStream(),
     through.obj(linkFile),
     options.unattach()

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "coveralls": "npm run cover && istanbul-coveralls"
   },
   "dependencies": {
+    "es6-weak-map": "^2.0.2",
     "flush-write-stream": "^1.0.0",
     "glob-stream": "^6.1.0",
     "graceful-fs": "^4.0.0",


### PR DESCRIPTION
@erikkemperman this is a concept of ditching `vinyl-prepare` given the options changes so things are consolidated once again.  Thoughts?