### PR TITLE
Simplify `useJunctions` default

### DIFF
--- a/lib/dest/options.js
+++ b/lib/dest/options.js
@@ -36,10 +36,7 @@ var config = {
   // Symlink options
   useJunctions: {
     type: 'boolean',
-    default: function(file) {
-      var isDirectory = file.isDirectory();
-      return (isWindows && isDirectory);
-    },
+    default: isWindows,
   },
   relative: {
     type: 'boolean',

--- a/lib/dest/write-contents/write-symbolic-link.js
+++ b/lib/dest/write-contents/write-symbolic-link.js
@@ -27,7 +27,7 @@ function writeSymbolicLink(file, optResolver, onWritten) {
   var isRelative = optResolver.resolve('relative', file);
 
   // This is done inside prepareWrite to use the adjusted file.base property
-  if (isRelative && !useJunctions) {
+  if (isRelative && symType !== 'junction') {
     srcPath = path.relative(file.base, srcPath);
   }
 

--- a/lib/symlink/link-file.js
+++ b/lib/symlink/link-file.js
@@ -32,7 +32,7 @@ function linkStream(optResolver) {
     var isRelative = optResolver.resolve('relative', file);
 
     // This is done inside prepareWrite to use the adjusted file.base property
-    if (isRelative && !useJunctions) {
+    if (isRelative && symType !== 'junction') {
       srcPath = path.relative(file.base, srcPath);
     }
 

--- a/lib/symlink/options.js
+++ b/lib/symlink/options.js
@@ -7,10 +7,7 @@ var isWindows = (os.platform() === 'win32');
 var config = {
   useJunctions: {
     type: 'boolean',
-    default: function(file) {
-      var isDirectory = file.isDirectory();
-      return (isWindows && isDirectory);
-    },
+    default: isWindows,
   },
   relative: {
     type: 'boolean',

--- a/test/dest-symlinks.js
+++ b/test/dest-symlinks.js
@@ -307,6 +307,36 @@ describe('.dest() with symlinks', function() {
     ], done);
   });
 
+  it('(windows) supports relative option when link is not for a directory', function(done) {
+    if (!isWindows) {
+      this.skip();
+      return;
+    }
+
+    var file = new File({
+      base: inputBase,
+      path: inputPath,
+      contents: null,
+    });
+
+    // `src()` adds this side-effect with `resolveSymlinks` option set to false
+    file.symlink = inputPath;
+
+    function assert(files) {
+      var outputLink = fs.readlinkSync(outputPath);
+
+      expect(files.length).toEqual(1);
+      expect(outputLink).toEqual(path.normalize('../fixtures/test.txt'));
+    }
+
+    pipe([
+      from.obj([file]),
+      // The useJunctions option is ignored when file is not a directory
+      vfs.dest(outputBase, { useJunctions: true, relative: true }),
+      concat(assert),
+    ], done);
+  });
+
   it('(windows) can create relative links for directories when junctions are disabled', function(done) {
     if (!isWindows) {
       this.skip();

--- a/test/symlink.js
+++ b/test/symlink.js
@@ -449,6 +449,36 @@ describe('symlink stream', function() {
     ], done);
   });
 
+  it('(windows) supports relative option when link is not for a directory', function(done) {
+    if (!isWindows) {
+      this.skip();
+      return;
+    }
+
+    var file = new File({
+      base: inputBase,
+      path: inputPath,
+      contents: null,
+    });
+
+    function assert(files) {
+      var outputLink = fs.readlinkSync(outputPath);
+
+      expect(files.length).toEqual(1);
+      expect(files).toInclude(file);
+      expect(files[0].base).toEqual(outputBase, 'base should have changed');
+      expect(files[0].path).toEqual(outputPath, 'path should have changed');
+      expect(outputLink).toEqual(path.normalize('../fixtures/test.txt'));
+    }
+
+    pipe([
+      from.obj([file]),
+      // The useJunctions option is ignored when file is not a directory
+      vfs.symlink(outputBase, { useJunctions: true, relative: true }),
+      concat(assert),
+    ], done);
+  });
+
   it('(windows) can create relative links for directories when junctions are disabled', function(done) {
     if (!isWindows) {
       this.skip();


### PR DESCRIPTION
With this change, I think it was proper to change the `relative` logic to check against the `symType` and only reject the option if it is trying to generate a `junction`.

I also added more tests for the scenario I am solving with these changes.

/cc @erikkemperman 