### PR TITLE
Update: attach symlink property (fixes #249)

### DIFF
--- a/lib/dest/write-contents/write-symbolic-link.js
+++ b/lib/dest/write-contents/write-symbolic-link.js
@@ -5,8 +5,6 @@ var path = require('path');
 var fo = require('../../file-operations');
 
 function writeSymbolicLink(file, optResolver, onWritten) {
-  var srcPath = file.symlink;
-
   var isDirectory = file.isDirectory();
 
   // This option provides a way to create a Junction instead of a
@@ -26,9 +24,9 @@ function writeSymbolicLink(file, optResolver, onWritten) {
   var symType = isDirectory ? symDirType : 'file';
   var isRelative = optResolver.resolve('relative', file);
 
-  // This is done inside prepareWrite to use the adjusted file.base property
+  // This is done after prepare() to use the adjusted file.base property
   if (isRelative && !useJunctions) {
-    srcPath = path.relative(file.base, srcPath);
+    file.symlink = path.relative(file.base, file.symlink);
   }
 
   var flag = optResolver.resolve('flag', file);
@@ -38,7 +36,7 @@ function writeSymbolicLink(file, optResolver, onWritten) {
     type: symType,
   };
 
-  fo.symlink(srcPath, file.path, opts, onWritten);
+  fo.symlink(file.symlink, file.path, opts, onWritten);
 }
 
 module.exports = writeSymbolicLink;

--- a/lib/symlink/link-file.js
+++ b/lib/symlink/link-file.js
@@ -9,9 +9,6 @@ var fo = require('../file-operations');
 function linkStream(optResolver) {
 
   function linkFile(file, enc, callback) {
-    // Fetch the path as it was before prepare.dest()
-    var srcPath = file.history[file.history.length - 2];
-
     var isDirectory = file.isDirectory();
 
     // This option provides a way to create a Junction instead of a
@@ -31,9 +28,9 @@ function linkStream(optResolver) {
     var symType = isDirectory ? symDirType : 'file';
     var isRelative = optResolver.resolve('relative', file);
 
-    // This is done inside prepareWrite to use the adjusted file.base property
+    // This is done after prepare() to use the adjusted file.base property
     if (isRelative && !useJunctions) {
-      srcPath = path.relative(file.base, srcPath);
+      file.symlink = path.relative(file.base, file.symlink);
     }
 
     var flag = optResolver.resolve('flag', file);
@@ -43,7 +40,7 @@ function linkStream(optResolver) {
       type: symType,
     };
 
-    fo.symlink(srcPath, file.path, opts, onSymlink);
+    fo.symlink(file.symlink, file.path, opts, onSymlink);
 
     function onSymlink(symlinkErr) {
       if (symlinkErr) {

--- a/lib/symlink/prepare.js
+++ b/lib/symlink/prepare.js
@@ -28,6 +28,7 @@ function prepareSymlink(folderResolver, optResolver) {
     file.stat.mode = mode;
     file.cwd = cwd;
     file.base = basePath;
+    file.symlink = file.path;
     file.path = writePath;
 
     cb(null, file);

--- a/test/symlink.js
+++ b/test/symlink.js
@@ -110,6 +110,7 @@ describe('symlink stream', function() {
       expect(files).toInclude(file);
       expect(files[0].base).toEqual(outputBase, 'base should have changed');
       expect(files[0].path).toEqual(outputPath, 'path should have changed');
+      expect(files[0].symlink).toEqual(outputLink, 'symlink should be set');
       expect(outputLink).toEqual(inputPath);
     }
 
@@ -142,6 +143,7 @@ describe('symlink stream', function() {
       expect(files).toInclude(file);
       expect(files[0].base).toEqual(outputBase, 'base should have changed');
       expect(files[0].path).toEqual(outputPath, 'path should have changed');
+      expect(files[0].symlink).toEqual(outputLink, 'symlink should be set');
       expect(outputLink).toEqual(inputPath);
     }
 
@@ -167,6 +169,7 @@ describe('symlink stream', function() {
       expect(files).toInclude(file);
       expect(files[0].base).toEqual(outputBase, 'base should have changed');
       expect(files[0].path).toEqual(outputPath, 'path should have changed');
+      expect(files[0].symlink).toEqual(outputLink, 'symlink should be set');
       expect(outputLink).toEqual(inputPath);
     }
 
@@ -191,6 +194,7 @@ describe('symlink stream', function() {
       expect(files).toInclude(file);
       expect(files[0].base).toEqual(outputBase, 'base should have changed');
       expect(files[0].path).toEqual(outputPath, 'path should have changed');
+      expect(files[0].symlink).toEqual(outputLink, 'symlink should be set');
       expect(outputLink).toEqual(path.normalize('../fixtures/test.txt'));
     }
 
@@ -215,6 +219,7 @@ describe('symlink stream', function() {
       expect(files).toInclude(file);
       expect(files[0].base).toEqual(outputBase, 'base should have changed');
       expect(files[0].path).toEqual(outputPath, 'path should have changed');
+      expect(files[0].symlink).toEqual(outputLink, 'symlink should be set');
       expect(outputLink).toEqual(inputPath);
     }
 
@@ -249,6 +254,7 @@ describe('symlink stream', function() {
       expect(files).toInclude(file);
       expect(files[0].base).toEqual(outputBase, 'base should have changed');
       expect(files[0].path).toEqual(outputDirpath, 'path should have changed');
+      expect(files[0].symlink).toEqual(outputLink, 'symlink should be set');
       expect(outputLink).toEqual(inputDirpath);
       expect(stats.isDirectory()).toEqual(true);
       expect(lstats.isDirectory()).toEqual(false);
@@ -286,6 +292,7 @@ describe('symlink stream', function() {
       expect(files[0].base).toEqual(outputBase, 'base should have changed');
       expect(files[0].path).toEqual(outputDirpath, 'path should have changed');
       // When creating a junction, it seems Windows appends a separator
+      expect(files[0].symlink + path.sep).toEqual(outputLink, 'symlink should be set');
       expect(outputLink).toEqual(inputDirpath + path.sep);
       expect(stats.isDirectory()).toEqual(true);
       expect(lstats.isDirectory()).toEqual(false);
@@ -322,6 +329,7 @@ describe('symlink stream', function() {
       expect(files).toInclude(file);
       expect(files[0].base).toEqual(outputBase, 'base should have changed');
       expect(files[0].path).toEqual(outputDirpath, 'path should have changed');
+      expect(files[0].symlink).toEqual(outputLink, 'symlink should be set');
       expect(outputLink).toEqual(inputDirpath);
       expect(stats.isDirectory()).toEqual(true);
       expect(lstats.isDirectory()).toEqual(false);
@@ -364,6 +372,7 @@ describe('symlink stream', function() {
       expect(files).toInclude(file);
       expect(files[0].base).toEqual(outputBase, 'base should have changed');
       expect(files[0].path).toEqual(outputDirpath, 'path should have changed');
+      expect(files[0].symlink).toEqual(outputLink, 'symlink should be set');
       expect(outputLink).toEqual(inputDirpath);
       expect(stats.isDirectory()).toEqual(true);
       expect(lstats.isDirectory()).toEqual(false);
@@ -400,6 +409,7 @@ describe('symlink stream', function() {
       expect(files).toInclude(file);
       expect(files[0].base).toEqual(outputBase, 'base should have changed');
       expect(files[0].path).toEqual(outputDirpath, 'path should have changed');
+      expect(files[0].symlink).toEqual(outputLink, 'symlink should be set');
       expect(outputLink).toEqual(path.normalize('../fixtures/foo'));
       expect(stats.isDirectory()).toEqual(true);
       expect(lstats.isDirectory()).toEqual(false);
@@ -437,6 +447,7 @@ describe('symlink stream', function() {
       expect(files[0].base).toEqual(outputBase, 'base should have changed');
       expect(files[0].path).toEqual(outputDirpath, 'path should have changed');
       // When creating a junction, it seems Windows appends a separator
+      expect(files[0].symlink + path.sep).toEqual(outputLink, 'symlink should be set');
       expect(outputLink).toEqual(inputDirpath + path.sep);
       expect(stats.isDirectory()).toEqual(true);
       expect(lstats.isDirectory()).toEqual(false);
@@ -473,6 +484,7 @@ describe('symlink stream', function() {
       expect(files).toInclude(file);
       expect(files[0].base).toEqual(outputBase, 'base should have changed');
       expect(files[0].path).toEqual(outputDirpath, 'path should have changed');
+      expect(files[0].symlink).toEqual(outputLink, 'symlink should be set');
       expect(outputLink).toEqual(path.normalize('../fixtures/foo'));
       expect(stats.isDirectory()).toEqual(true);
       expect(lstats.isDirectory()).toEqual(false);


### PR DESCRIPTION
I ended up figuring the correct thing to do here is to have the `symlink` property be relative when created with the `relative` option set to true, and absolute otherwise. This mirrors the behaviour of `src` when reading links.

One slight quirk to notice is that we can't tell from just this property if the link is a junction: the trailing path separator it would have after `fs.readLink` is normalized off by the setter in vinyl. It's probably no big deal.

This is going to conflict with your other symlink PR, I expect, but it should be trivial to resolve.