### PR TITLE
Symlink/Junction improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,10 +211,11 @@ Default: `false`
 ##### `options.useJunctions`
 
 When creating a symlink, whether or not a directory symlink should be created as a `junction`.
+This option is only relevant on Windows and ignored elsewhere.
 
 Type: `Boolean`
 
-Default: `true` on Windows, `false` on all other platforms
+Default: `true`
 
 ### `symlink(folder[, options])`
 
@@ -238,14 +239,6 @@ The working directory the folder is relative to.
 Type: `String`
 
 Default: `process.cwd()`
-
-##### `options.mode`
-
-The mode the symlinks should be created with.
-
-Type: `Number`
-
-Default: The `mode` of the input file (`file.stat.mode`) if any, or the process mode if the input file has no `mode` property.
 
 ##### `options.dirMode`
 
@@ -274,10 +267,11 @@ Default: `false`
 ##### `options.useJunctions`
 
 Whether or not a directory symlink should be created as a `junction`.
+This option is only relevant on Windows and ignored elsewhere.
 
 Type: `Boolean`
 
-Default: `true` on Windows, `false` on all other platforms
+Default: `true`
 
 [glob-stream]: https://github.com/gulpjs/glob-stream
 [node-glob]: https://github.com/isaacs/node-glob

--- a/lib/dest/options.js
+++ b/lib/dest/options.js
@@ -1,9 +1,5 @@
 'use strict';
 
-var os = require('os');
-
-var isWindows = (os.platform() === 'win32');
-
 var config = {
   cwd: {
     type: 'string',
@@ -34,13 +30,14 @@ var config = {
     default: false,
   },
   // Symlink options
-  useJunctions: {
-    type: 'boolean',
-    default: isWindows,
-  },
   relativeSymlinks: {
     type: 'boolean',
     default: false,
+  },
+  // This option is ignored on non-Windows platforms
+  useJunctions: {
+    type: 'boolean',
+    default: true,
   },
 };
 

--- a/lib/dest/prepare.js
+++ b/lib/dest/prepare.js
@@ -11,22 +11,23 @@ function prepareWrite(folderResolver, optResolver) {
   }
 
   function normalize(file, enc, cb) {
-    var mode = optResolver.resolve('mode', file);
-    var cwd = path.resolve(optResolver.resolve('cwd', file));
-
     var outFolderPath = folderResolver.resolve('outFolder', file);
     if (!outFolderPath) {
       return cb(new Error('Invalid output folder'));
     }
+    var cwd = path.resolve(optResolver.resolve('cwd', file));
     var basePath = path.resolve(cwd, outFolderPath);
     var writePath = path.resolve(basePath, file.relative);
 
     // Wire up new properties
-    file.stat = (file.stat || new fs.Stats());
-    file.stat.mode = mode;
     file.cwd = cwd;
     file.base = basePath;
     file.path = writePath;
+    if (!file.isSymbolic()) {
+      var mode = optResolver.resolve('mode', file);
+      file.stat = (file.stat || new fs.Stats());
+      file.stat.mode = mode;
+    }
 
     cb(null, file);
   }

--- a/lib/dest/write-contents/index.js
+++ b/lib/dest/write-contents/index.js
@@ -13,7 +13,7 @@ function writeContents(optResolver) {
 
   function writeFile(file, enc, callback) {
     // Write it as a symlink
-    if (file.symlink) {
+    if (file.isSymbolic()) {
       return writeSymbolicLink(file, optResolver, onWritten);
     }
 

--- a/lib/dest/write-contents/write-symbolic-link.js
+++ b/lib/dest/write-contents/write-symbolic-link.js
@@ -1,42 +1,74 @@
 'use strict';
 
+var os = require('os');
 var path = require('path');
 
 var fo = require('../../file-operations');
 
+var isWindows = (os.platform() === 'win32');
+
 function writeSymbolicLink(file, optResolver, onWritten) {
-  var isDirectory = file.isDirectory();
-
-  // This option provides a way to create a Junction instead of a
-  // Directory symlink on Windows. This comes with the following caveats:
-  // * NTFS Junctions cannot be relative.
-  // * NTFS Junctions MUST be directories.
-  // * NTFS Junctions must be on the same file system.
-  // * Most products CANNOT detect a directory is a Junction:
-  //    This has the side effect of possibly having a whole directory
-  //    deleted when a product is deleting the Junction directory.
-  //    For example, JetBrains product lines will delete the entire
-  //    contents of the TARGET directory because the product does not
-  //    realize it's a symlink as the JVM and Node return false for isSymlink.
-  var useJunctions = optResolver.resolve('useJunctions', file);
-
-  var symDirType =  useJunctions ? 'junction' : 'dir';
-  var symType = isDirectory ? symDirType : 'file';
-  var isRelative = optResolver.resolve('relativeSymlinks', file);
-
-  // This is done after prepare() to use the adjusted file.base property
-  if (isRelative && symType !== 'junction') {
-    file.symlink = path.relative(file.base, file.symlink);
+  if (!file.symlink) {
+    return onWritten(new Error('Missing symlink property on symbolic vinyl'));
   }
 
+  var isRelative = optResolver.resolve('relativeSymlinks', file);
   var flag = optResolver.resolve('flag', file);
 
-  var opts = {
-    flag: flag,
-    type: symType,
-  };
+  if (!isWindows) {
+    // On non-Windows, just use 'file'
+    return createLinkWithType('file');
+  }
 
-  fo.symlink(file.symlink, file.path, opts, onWritten);
+  fo.reflectStat(file.symlink, file, onReflect);
+
+  function onReflect(statErr) {
+    if (statErr && statErr.code !== 'ENOENT') {
+      return onWritten(statErr);
+    }
+
+    // This option provides a way to create a Junction instead of a
+    // Directory symlink on Windows. This comes with the following caveats:
+    // * NTFS Junctions cannot be relative.
+    // * NTFS Junctions MUST be directories.
+    // * NTFS Junctions must be on the same file system.
+    // * Most products CANNOT detect a directory is a Junction:
+    //    This has the side effect of possibly having a whole directory
+    //    deleted when a product is deleting the Junction directory.
+    //    For example, JetBrains product lines will delete the entire contents
+    //    of the TARGET directory because the product does not realize it's
+    //    a symlink as the JVM and Node return false for isSymlink.
+
+    // This function is Windows only, so we don't need to check again
+    var useJunctions = optResolver.resolve('useJunctions', file);
+
+    var dirType = useJunctions ? 'junction' : 'dir';
+    // Dangling links are always 'file'
+    var type = !statErr && file.isDirectory() ? dirType : 'file';
+
+    createLinkWithType(type);
+  }
+
+  function createLinkWithType(type) {
+    // This is done after prepare() to use the adjusted file.base property
+    if (isRelative && type !== 'junction') {
+      file.symlink = path.relative(file.base, file.symlink);
+    }
+
+    var opts = {
+      flag: flag,
+      type: type,
+    };
+    fo.symlink(file.symlink, file.path, opts, onSymlink);
+
+    function onSymlink(symlinkErr) {
+      if (symlinkErr) {
+        return onWritten(symlinkErr);
+      }
+
+      fo.reflectLinkStat(file.path, file, onWritten);
+    }
+  }
 }
 
 module.exports = writeSymbolicLink;

--- a/lib/file-operations.js
+++ b/lib/file-operations.js
@@ -155,6 +155,34 @@ function isOwner(fsStat) {
   return true;
 }
 
+function reflectStat(path, file, callback) {
+  // Set file.stat to the reflect current state on disk
+  fs.stat(path, onStat);
+
+  function onStat(statErr, stat) {
+    if (statErr) {
+      return callback(statErr);
+    }
+
+    file.stat = stat;
+    callback();
+  }
+}
+
+function reflectLinkStat(path, file, callback) {
+  // Set file.stat to the reflect current state on disk
+  fs.lstat(path, onLstat);
+
+  function onLstat(lstatErr, stat) {
+    if (lstatErr) {
+      return callback(lstatErr);
+    }
+
+    file.stat = stat;
+    callback();
+  }
+}
+
 function updateMetadata(fd, file, callback) {
 
   fs.fstat(fd, onStat);
@@ -413,6 +441,8 @@ module.exports = {
   getTimesDiff: getTimesDiff,
   getOwnerDiff: getOwnerDiff,
   isOwner: isOwner,
+  reflectStat: reflectStat,
+  reflectLinkStat: reflectLinkStat,
   updateMetadata: updateMetadata,
   symlink: symlink,
   writeFile: writeFile,

--- a/lib/src/resolve-symlinks.js
+++ b/lib/src/resolve-symlinks.js
@@ -1,23 +1,21 @@
 'use strict';
 
 var through = require('through2');
-var fs = require('graceful-fs');
+var fo = require('../file-operations');
 
 function resolveSymlinks(optResolver) {
 
   // A stat property is exposed on file objects as a (wanted) side effect
   function resolveFile(file, enc, callback) {
 
-    fs.lstat(file.path, onStat);
+    fo.reflectLinkStat(file.path, file, onReflect);
 
-    function onStat(statErr, stat) {
+    function onReflect(statErr) {
       if (statErr) {
         return callback(statErr);
       }
 
-      file.stat = stat;
-
-      if (!stat.isSymbolicLink()) {
+      if (!file.stat.isSymbolicLink()) {
         return callback(null, file);
       }
 
@@ -27,8 +25,8 @@ function resolveSymlinks(optResolver) {
         return callback(null, file);
       }
 
-      // Recurse to get real file stat
-      fs.stat(file.path, onStat);
+      // Get target's stats
+      fo.reflectStat(file.path, file, onReflect);
     }
   }
 

--- a/lib/symlink/link-file.js
+++ b/lib/symlink/link-file.js
@@ -1,50 +1,79 @@
 'use strict';
 
+var os = require('os');
 var path = require('path');
 
 var through = require('through2');
 
 var fo = require('../file-operations');
 
+var isWindows = (os.platform() === 'win32');
+
 function linkStream(optResolver) {
 
   function linkFile(file, enc, callback) {
-    var isDirectory = file.isDirectory();
-
-    // This option provides a way to create a Junction instead of a
-    // Directory symlink on Windows. This comes with the following caveats:
-    // * NTFS Junctions cannot be relative.
-    // * NTFS Junctions MUST be directories.
-    // * NTFS Junctions must be on the same file system.
-    // * Most products CANNOT detect a directory is a Junction:
-    //    This has the side effect of possibly having a whole directory
-    //    deleted when a product is deleting the Junction directory.
-    //    For example, JetBrains product lines will delete the entire
-    //    contents of the TARGET directory because the product does not
-    //    realize it's a symlink as the JVM and Node return false for isSymlink.
-    var useJunctions = optResolver.resolve('useJunctions', file);
-
-    var symDirType =  useJunctions ? 'junction' : 'dir';
-    var symType = isDirectory ? symDirType : 'file';
     var isRelative = optResolver.resolve('relativeSymlinks', file);
-
-    // This is done after prepare() to use the adjusted file.base property
-    if (isRelative && symType !== 'junction') {
-      file.symlink = path.relative(file.base, file.symlink);
-    }
-
     var flag = optResolver.resolve('flag', file);
 
-    var opts = {
-      flag: flag,
-      type: symType,
-    };
+    if (!isWindows) {
+      // On non-Windows, just use 'file'
+      return createLinkWithType('file');
+    }
 
-    fo.symlink(file.symlink, file.path, opts, onSymlink);
+    fo.reflectStat(file.symlink, file, onReflectTarget);
+
+    function onReflectTarget(statErr) {
+      if (statErr && statErr.code !== 'ENOENT') {
+        return onWritten(statErr);
+      }
+      // If target doesn't exist, the vinyl will still carry the target stats.
+      // Let's use those to determine which kind of dangling link to create.
+
+      // This option provides a way to create a Junction instead of a
+      // Directory symlink on Windows. This comes with the following caveats:
+      // * NTFS Junctions cannot be relative.
+      // * NTFS Junctions MUST be directories.
+      // * NTFS Junctions must be on the same file system.
+      // * Most products CANNOT detect a directory is a Junction:
+      //    This has the side effect of possibly having a whole directory
+      //    deleted when a product is deleting the Junction directory.
+      //    For example, JetBrains product lines will delete the entire contents
+      //    of the TARGET directory because the product does not realize it's
+      //    a symlink as the JVM and Node return false for isSymlink.
+
+      // This function is Windows only, so we don't need to check again
+      var useJunctions = optResolver.resolve('useJunctions', file);
+
+      var dirType = useJunctions ? 'junction' : 'dir';
+      var type = !statErr && file.isDirectory() ? dirType : 'file';
+
+      createLinkWithType(type);
+    }
+
+    function createLinkWithType(type) {
+      // This is done after prepare() to use the adjusted file.base property
+      if (isRelative && type !== 'junction') {
+        file.symlink = path.relative(file.base, file.symlink);
+      }
+
+      var opts = {
+        flag: flag,
+        type: type,
+      };
+      fo.symlink(file.symlink, file.path, opts, onSymlink);
+    }
 
     function onSymlink(symlinkErr) {
       if (symlinkErr) {
         return callback(symlinkErr);
+      }
+
+      fo.reflectLinkStat(file.path, file, onReflectLink);
+    }
+
+    function onReflectLink(reflectErr) {
+      if (reflectErr) {
+        return callback(reflectErr);
       }
 
       callback(null, file);

--- a/lib/symlink/options.js
+++ b/lib/symlink/options.js
@@ -1,13 +1,10 @@
 'use strict';
 
-var os = require('os');
-
-var isWindows = (os.platform() === 'win32');
-
 var config = {
+  // This option is ignored on non-Windows platforms
   useJunctions: {
     type: 'boolean',
-    default: isWindows,
+    default: true,
   },
   relativeSymlinks: {
     type: 'boolean',
@@ -16,12 +13,6 @@ var config = {
   cwd: {
     type: 'string',
     default: process.cwd,
-  },
-  mode: {
-    type: 'number',
-    default: function(file) {
-      return file.stat ? file.stat.mode : null;
-    },
   },
   dirMode: {
     type: 'number',

--- a/lib/symlink/prepare.js
+++ b/lib/symlink/prepare.js
@@ -1,7 +1,5 @@
 'use strict';
 
-// TODO: currently a copy-paste of prepareWrite but should be customized
-
 var path = require('path');
 
 var fs = require('graceful-fs');
@@ -13,7 +11,6 @@ function prepareSymlink(folderResolver, optResolver) {
   }
 
   function normalize(file, enc, cb) {
-    var mode = optResolver.resolve('mode', file);
     var cwd = path.resolve(optResolver.resolve('cwd', file));
 
     var outFolderPath = folderResolver.resolve('outFolder', file);
@@ -24,12 +21,16 @@ function prepareSymlink(folderResolver, optResolver) {
     var writePath = path.resolve(basePath, file.relative);
 
     // Wire up new properties
+    // Note: keep the target stats for now, we may need them in link-file
     file.stat = (file.stat || new fs.Stats());
-    file.stat.mode = mode;
     file.cwd = cwd;
     file.base = basePath;
+    // This is the path we are linking *TO*
     file.symlink = file.path;
     file.path = writePath;
+    // We have to set contents to null for a link
+    // Otherwise `isSymbolic()` returns false
+    file.contents = null;
 
     cb(null, file);
   }

--- a/test/dest-modes.js
+++ b/test/dest-modes.js
@@ -12,7 +12,7 @@ var statMode = require('./utils/stat-mode');
 var mockError = require('./utils/mock-error');
 var isWindows = require('./utils/is-windows');
 var applyUmask = require('./utils/apply-umask');
-var isDirectory = require('./utils/is-directory-mock');
+var always = require('./utils/always');
 var testConstants = require('./utils/test-constants');
 
 var from = miss.from;
@@ -135,7 +135,7 @@ describe('.dest() with custom modes', function() {
       path: inputDirpath,
       contents: null,
       stat: {
-        isDirectory: isDirectory,
+        isDirectory: always(true),
         mode: expectedMode,
       },
     });
@@ -164,7 +164,7 @@ describe('.dest() with custom modes', function() {
       path: inputDirpath,
       contents: null,
       stat: {
-        isDirectory: isDirectory,
+        isDirectory: always(true),
         mode: expectedMode,
       },
     });
@@ -251,7 +251,7 @@ describe('.dest() with custom modes', function() {
       base: inputBase,
       path: outputDirpath,
       stat: {
-        isDirectory: isDirectory,
+        isDirectory: always(true),
         mode: startMode,
       },
     });
@@ -259,7 +259,7 @@ describe('.dest() with custom modes', function() {
       base: inputBase,
       path: outputDirpath,
       stat: {
-        isDirectory: isDirectory,
+        isDirectory: always(true),
         mode: expectedMode,
       },
     });

--- a/test/dest-symlinks.js
+++ b/test/dest-symlinks.js
@@ -11,8 +11,7 @@ var vfs = require('../');
 
 var cleanup = require('./utils/cleanup');
 var isWindows = require('./utils/is-windows');
-var isDirectory = require('./utils/is-directory-mock');
-var isSymbolicLink = require('./utils/is-symbolic-link-mock');
+var always = require('./utils/always');
 var testConstants = require('./utils/test-constants');
 
 var from = miss.from;
@@ -45,7 +44,7 @@ describe('.dest() with symlinks', function() {
       path: inputPath,
       contents: null,
       stat: {
-        isSymbolicLink: isSymbolicLink,
+        isSymbolicLink: always(true),
       },
     });
 
@@ -58,6 +57,7 @@ describe('.dest() with symlinks', function() {
       expect(files.length).toEqual(1);
       expect(file.symlink).toEqual(symlink);
       expect(files[0].symlink).toEqual(symlink);
+      expect(files[0].isSymbolic()).toBe(true);
       expect(files[0].path).toEqual(outputPath);
     }
 
@@ -74,9 +74,7 @@ describe('.dest() with symlinks', function() {
       path: inputPath,
       contents: null,
       stat: {
-        isSymbolicLink: function() {
-          return false;
-        },
+        isSymbolicLink: always(false),
       },
     });
 
@@ -103,13 +101,13 @@ describe('.dest() with symlinks', function() {
       path: inputPath,
       contents: null,
       stat: {
-        isSymbolicLink: isSymbolicLink,
+        isSymbolicLink: always(true),
       },
     });
 
     function assert(err) {
       expect(err).toExist();
-      // TODO: Should we assert anything else about this err?
+      expect(err.message).toEqual('Missing symlink property on symbolic vinyl');
       done();
     }
 
@@ -119,13 +117,13 @@ describe('.dest() with symlinks', function() {
     ], assert);
   });
 
-  it('emits Vinyl files that are symbolic', function(done) {
+  it('emits Vinyl files that are (still) symbolic', function(done) {
     var file = new File({
       base: inputBase,
       path: inputPath,
       contents: null,
       stat: {
-        isSymbolicLink: isSymbolicLink,
+        isSymbolicLink: always(true),
       },
     });
 
@@ -150,7 +148,7 @@ describe('.dest() with symlinks', function() {
       path: inputPath,
       contents: null,
       stat: {
-        isSymbolicLink: isSymbolicLink,
+        isSymbolicLink: always(true),
       },
     });
 
@@ -162,6 +160,7 @@ describe('.dest() with symlinks', function() {
 
       expect(files.length).toEqual(1);
       expect(outputLink).toEqual(path.normalize('../fixtures/test.txt'));
+      expect(files[0].isSymbolic()).toBe(true);
     }
 
     pipe([
@@ -182,7 +181,7 @@ describe('.dest() with symlinks', function() {
       path: inputDirpath,
       contents: null,
       stat: {
-        isSymbolicLink: isSymbolicLink,
+        isSymbolicLink: always(true),
       },
     });
 
@@ -218,7 +217,7 @@ describe('.dest() with symlinks', function() {
       path: inputDirpath,
       contents: null,
       stat: {
-        isSymbolicLink: isSymbolicLink,
+        isSymbolicLink: always(true),
       },
     });
 
@@ -255,7 +254,7 @@ describe('.dest() with symlinks', function() {
       path: inputDirpath,
       contents: null,
       stat: {
-        isSymbolicLink: isSymbolicLink,
+        isSymbolicLink: always(true),
       },
     });
 
@@ -291,7 +290,7 @@ describe('.dest() with symlinks', function() {
       path: inputDirpath,
       contents: null,
       stat: {
-        isSymbolicLink: isSymbolicLink,
+        isSymbolicLink: always(true),
       },
     });
 
@@ -333,7 +332,7 @@ describe('.dest() with symlinks', function() {
       path: inputDirpath,
       contents: null,
       stat: {
-        isSymbolicLink: isSymbolicLink,
+        isSymbolicLink: always(true),
       },
     });
 
@@ -369,7 +368,7 @@ describe('.dest() with symlinks', function() {
       path: neInputDirpath,
       contents: null,
       stat: {
-        isSymbolicLink: isSymbolicLink,
+        isSymbolicLink: always(true),
       },
     });
 
@@ -409,7 +408,7 @@ describe('.dest() with symlinks', function() {
       path: neInputDirpath,
       contents: null,
       stat: {
-        isSymbolicLink: isSymbolicLink,
+        isSymbolicLink: always(true),
       },
     });
 
@@ -446,7 +445,7 @@ describe('.dest() with symlinks', function() {
       path: inputDirpath,
       contents: null,
       stat: {
-        isSymbolicLink: isSymbolicLink,
+        isSymbolicLink: always(true),
       },
     });
 
@@ -483,7 +482,7 @@ describe('.dest() with symlinks', function() {
       path: inputPath,
       contents: null,
       stat: {
-        isSymbolicLink: isSymbolicLink,
+        isSymbolicLink: always(true),
       },
     });
 
@@ -516,7 +515,7 @@ describe('.dest() with symlinks', function() {
       path: inputDirpath,
       contents: null,
       stat: {
-        isSymbolicLink: isSymbolicLink,
+        isSymbolicLink: always(true),
       },
     });
 
@@ -552,7 +551,7 @@ describe('.dest() with symlinks', function() {
       path: inputPath,
       contents: null,
       stat: {
-        isSymbolicLink: isSymbolicLink,
+        isSymbolicLink: always(true),
       },
     });
 
@@ -586,7 +585,7 @@ describe('.dest() with symlinks', function() {
       path: inputPath,
       contents: null,
       stat: {
-        isSymbolicLink: isSymbolicLink,
+        isSymbolicLink: always(true),
       },
     });
 
@@ -619,7 +618,7 @@ describe('.dest() with symlinks', function() {
       path: inputPath,
       contents: null,
       stat: {
-        isSymbolicLink: isSymbolicLink,
+        isSymbolicLink: always(true),
       },
     });
 
@@ -657,7 +656,7 @@ describe('.dest() with symlinks', function() {
       path: inputPath,
       contents: null,
       stat: {
-        isSymbolicLink: isSymbolicLink,
+        isSymbolicLink: always(true),
       },
     });
 

--- a/test/dest.js
+++ b/test/dest.js
@@ -14,7 +14,7 @@ var statMode = require('./utils/stat-mode');
 var mockError = require('./utils/mock-error');
 var applyUmask = require('./utils/apply-umask');
 var testStreams = require('./utils/test-streams');
-var isDirectory = require('./utils/is-directory-mock');
+var always = require('./utils/always');
 var testConstants = require('./utils/test-constants');
 
 var from = miss.from;
@@ -368,7 +368,7 @@ describe('.dest()', function() {
       path: inputDirpath,
       contents: null,
       stat: {
-        isDirectory: isDirectory,
+        isDirectory: always(true),
       },
     });
 
@@ -828,7 +828,7 @@ describe('.dest()', function() {
       path: inputDirpath,
       contents: null,
       stat: {
-        isDirectory: isDirectory,
+        isDirectory: always(true),
       },
     });
 
@@ -851,7 +851,7 @@ describe('.dest()', function() {
       path: inputDirpath,
       contents: null,
       stat: {
-        isDirectory: isDirectory,
+        isDirectory: always(true),
         mode: applyUmask('000'),
       },
     });
@@ -876,7 +876,7 @@ describe('.dest()', function() {
       path: inputDirpath,
       contents: null,
       stat: {
-        isDirectory: isDirectory,
+        isDirectory: always(true),
       },
     });
 

--- a/test/src-symlinks.js
+++ b/test/src-symlinks.js
@@ -7,6 +7,7 @@ var miss = require('mississippi');
 var vfs = require('../');
 
 var cleanup = require('./utils/cleanup');
+var isWindows = require('./utils/is-windows');
 var testConstants = require('./utils/test-constants');
 
 var pipe = miss.pipe;

--- a/test/src-symlinks.js
+++ b/test/src-symlinks.js
@@ -7,7 +7,6 @@ var miss = require('mississippi');
 var vfs = require('../');
 
 var cleanup = require('./utils/cleanup');
-var isWindows = require('./utils/is-windows');
 var testConstants = require('./utils/test-constants');
 
 var pipe = miss.pipe;
@@ -128,7 +127,7 @@ describe('.src() with symlinks', function() {
     ], done);
   });
 
-  it('recieves a file with symbolic link stats when resolveSymlinks is a function', function(done) {
+  it('receives a file with symbolic link stats when resolveSymlinks is a function', function(done) {
 
     function resolveSymlinks(file) {
       expect(file).toExist();

--- a/test/symlink.js
+++ b/test/symlink.js
@@ -230,6 +230,25 @@ describe('symlink stream', function() {
     ], done);
   });
 
+  it('emits Vinyl objects that are symbolic', function(done) {
+    var file = new File({
+      base: inputBase,
+      path: inputPath,
+      contents: null,
+    });
+
+    function assert(files) {
+      expect(files.length).toEqual(1);
+      expect(files[0].isSymbolic()).toEqual(true);
+    }
+
+    pipe([
+      from.obj([file]),
+      vfs.symlink(outputBase),
+      concat(assert),
+    ], done);
+  });
+
   it('(*nix) creates a link for a directory', function(done) {
     if (isWindows) {
       this.skip();

--- a/test/symlink.js
+++ b/test/symlink.js
@@ -10,11 +10,9 @@ var miss = require('mississippi');
 var vfs = require('../');
 
 var cleanup = require('./utils/cleanup');
-var statMode = require('./utils/stat-mode');
 var isWindows = require('./utils/is-windows');
-var applyUmask = require('./utils/apply-umask');
 var testStreams = require('./utils/test-streams');
-var isDirectory = require('./utils/is-directory-mock');
+var always = require('./utils/always');
 var testConstants = require('./utils/test-constants');
 
 var from = miss.from;
@@ -111,6 +109,7 @@ describe('symlink stream', function() {
       expect(files[0].base).toEqual(outputBase, 'base should have changed');
       expect(files[0].path).toEqual(outputPath, 'path should have changed');
       expect(files[0].symlink).toEqual(outputLink, 'symlink should be set');
+      expect(files[0].isSymbolic()).toBe(true, 'file should be symbolic');
       expect(outputLink).toEqual(inputPath);
     }
 
@@ -144,6 +143,7 @@ describe('symlink stream', function() {
       expect(files[0].base).toEqual(outputBase, 'base should have changed');
       expect(files[0].path).toEqual(outputPath, 'path should have changed');
       expect(files[0].symlink).toEqual(outputLink, 'symlink should be set');
+      expect(files[0].isSymbolic()).toBe(true, 'file should be symbolic');
       expect(outputLink).toEqual(inputPath);
     }
 
@@ -154,7 +154,6 @@ describe('symlink stream', function() {
     ], done);
   });
 
-  // TODO: test for modes
   it('creates a link for a file with buffered contents', function(done) {
     var file = new File({
       base: inputBase,
@@ -170,6 +169,7 @@ describe('symlink stream', function() {
       expect(files[0].base).toEqual(outputBase, 'base should have changed');
       expect(files[0].path).toEqual(outputPath, 'path should have changed');
       expect(files[0].symlink).toEqual(outputLink, 'symlink should be set');
+      expect(files[0].isSymbolic()).toBe(true, 'file should be symbolic');
       expect(outputLink).toEqual(inputPath);
     }
 
@@ -195,6 +195,7 @@ describe('symlink stream', function() {
       expect(files[0].base).toEqual(outputBase, 'base should have changed');
       expect(files[0].path).toEqual(outputPath, 'path should have changed');
       expect(files[0].symlink).toEqual(outputLink, 'symlink should be set');
+      expect(files[0].isSymbolic()).toBe(true, 'file should be symbolic');
       expect(outputLink).toEqual(path.normalize('../fixtures/test.txt'));
     }
 
@@ -220,6 +221,7 @@ describe('symlink stream', function() {
       expect(files[0].base).toEqual(outputBase, 'base should have changed');
       expect(files[0].path).toEqual(outputPath, 'path should have changed');
       expect(files[0].symlink).toEqual(outputLink, 'symlink should be set');
+      expect(files[0].isSymbolic()).toBe(true, 'file should be symbolic');
       expect(outputLink).toEqual(inputPath);
     }
 
@@ -260,7 +262,7 @@ describe('symlink stream', function() {
       path: inputDirpath,
       contents: null,
       stat: {
-        isDirectory: isDirectory,
+        isDirectory: always(true),
       },
     });
 
@@ -297,7 +299,7 @@ describe('symlink stream', function() {
       path: inputDirpath,
       contents: null,
       stat: {
-        isDirectory: isDirectory,
+        isDirectory: always(true),
       },
     });
 
@@ -335,7 +337,7 @@ describe('symlink stream', function() {
       path: inputDirpath,
       contents: null,
       stat: {
-        isDirectory: isDirectory,
+        isDirectory: always(true),
       },
     });
 
@@ -372,7 +374,7 @@ describe('symlink stream', function() {
       path: inputDirpath,
       contents: null,
       stat: {
-        isDirectory: isDirectory,
+        isDirectory: always(true),
       },
     });
 
@@ -415,7 +417,7 @@ describe('symlink stream', function() {
       path: inputDirpath,
       contents: null,
       stat: {
-        isDirectory: isDirectory,
+        isDirectory: always(true),
       },
     });
 
@@ -452,7 +454,7 @@ describe('symlink stream', function() {
       path: inputDirpath,
       contents: null,
       stat: {
-        isDirectory: isDirectory,
+        isDirectory: always(true),
       },
     });
 
@@ -520,7 +522,7 @@ describe('symlink stream', function() {
       path: inputDirpath,
       contents: null,
       stat: {
-        isDirectory: isDirectory,
+        isDirectory: always(true),
       },
     });
 
@@ -542,35 +544,6 @@ describe('symlink stream', function() {
     pipe([
       from.obj([file]),
       vfs.symlink(outputBase, { useJunctions: false, relativeSymlinks: true }),
-      concat(assert),
-    ], done);
-  });
-
-  it('uses different modes for files and directories', function(done) {
-    // Changing the mode of a file is not supported by node.js in Windows.
-    if (isWindows) {
-      this.skip();
-      return;
-    }
-
-    var dirMode = applyUmask('722');
-    var fileMode = applyUmask('700');
-
-    var file = new File({
-      base: inputBase,
-      path: inputPath,
-      contents: null,
-    });
-
-    function assert(files) {
-      expect(statMode(outputDirpath)).toEqual(dirMode);
-      // TODO: the file doesn't actually get the mode updated
-      expect(files[0].stat.mode).toEqual(fileMode);
-    }
-
-    pipe([
-      from.obj([file]),
-      vfs.symlink(outputDirpath, { mode: fileMode, dirMode: dirMode }),
       concat(assert),
     ], done);
   });

--- a/test/utils/always.js
+++ b/test/utils/always.js
@@ -1,0 +1,9 @@
+'use strict';
+
+function always(value) {
+  return function() {
+    return value;
+  };
+}
+
+module.exports = always;

--- a/test/utils/is-directory-mock.js
+++ b/test/utils/is-directory-mock.js
@@ -1,7 +1,0 @@
-'use strict';
-
-function isDirectory() {
-  return true;
-}
-
-module.exports = isDirectory;

--- a/test/utils/is-symbolic-link-mock.js
+++ b/test/utils/is-symbolic-link-mock.js
@@ -1,7 +1,0 @@
-'use strict';
-
-function isSymbolic() {
-  return true;
-}
-
-module.exports = isSymbolic;

--- a/test/utils/is-symbolic-link-mock.js
+++ b/test/utils/is-symbolic-link-mock.js
@@ -1,0 +1,7 @@
+'use strict';
+
+function isSymbolic() {
+  return true;
+}
+
+module.exports = isSymbolic;

--- a/test/utils/test-constants.js
+++ b/test/utils/test-constants.js
@@ -34,6 +34,11 @@ var symlinkMultiDirpath = path.join(outputBase, './test-multi-layer-symlink-dir'
 var symlinkMultiDirpathSecond = path.join(outputBase, './test-multi-layer-symlink-dir2');
 var symlinkNestedFirst = path.join(outputBase, './test-multi-layer-symlink');
 var symlinkNestedSecond = path.join(outputBase, './foo/baz-link.txt');
+// Paths that don't exist
+var neInputBase = path.join(inputBase, './not-exists/');
+var neOutputBase = path.join(outputBase, './not-exists/');
+var neInputDirpath = path.join(neInputBase, './foo');
+var neOutputDirpath = path.join(neOutputBase, './foo');
 // Used for contents of files
 var contents = 'Hello World!\n';
 var sourcemapContents = '//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiLi9maXh0dXJlcyIsIm5hbWVzIjpbXSwibWFwcGluZ3MiOiIiLCJzb3VyY2VzIjpbIi4vZml4dHVyZXMiXSwic291cmNlc0NvbnRlbnQiOlsiSGVsbG8gV29ybGQhXG4iXX0=';
@@ -62,6 +67,10 @@ module.exports = {
   symlinkMultiDirpathSecond: symlinkMultiDirpathSecond,
   symlinkNestedFirst: symlinkNestedFirst,
   symlinkNestedSecond: symlinkNestedSecond,
+  neInputBase: neInputBase,
+  neOutputBase: neOutputBase,
+  neInputDirpath: neInputDirpath,
+  neOutputDirpath: neOutputDirpath,
   contents: contents,
   sourcemapContents: sourcemapContents,
 };


### PR DESCRIPTION
As a talking point for #248, I wanted to create a couple of "integration" tests that show why we should keep the `file.isDirectory()` call inside `.dest` and `.symlink` methods.

@erikkemperman what do you think?

TODO: remove the `.only` call on the integration suite