### PR TITLE
Fix utime-related test cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ If they differ and the running process owns the file, the corresponding filesyst
 If they don't differ or the process doesn't own the file, the attempt is skipped silently.
 __This functionality is disabled on Windows operating systems or any other OS that doesn't support `process.getuid` or `process.geteuid` in node. This is due to Windows having very unexpected results through usage of `fs.fchmod` and `fs.futimes`.__
 
+__Note: The `fs.futimes()` method internally casts `stat.mtime` and `stat.atime` to floats, which causes precision lost in 32bit Node.js.__
+
 If the file has a `symlink` attribute specifying a target path, then a symlink will be created.
 
 __Note: The file will be modified after being written to this stream.__

--- a/test/file-operations.js
+++ b/test/file-operations.js
@@ -1030,10 +1030,9 @@ describe('updateMetadata', function() {
 
     var futimesSpy = expect.spyOn(fs, 'futimes').andCallThrough();
 
-    // Use the mtime/atime of this file to have proper resolution
-    var stats = fs.statSync(__filename);
-    var mtime = stats.mtime;
-    var atime = stats.atime;
+    // Use new atime/mtime
+    var atime = new Date(Date.now() - 2048);
+    var mtime = new Date(Date.now() - 1024);
     var mtimeEarlier = mtime.getTime() - 1000;
     var atimeEarlier = atime.getTime() - 1000;
 
@@ -1051,12 +1050,15 @@ describe('updateMetadata', function() {
 
     updateMetadata(fd, file, function() {
       expect(futimesSpy.calls.length).toEqual(1);
-      var stats = fs.fstatSync(fd);
+      // Var stats = fs.fstatSync(fd);
+
+      var atimeSpy = futimesSpy.calls[0].arguments[1];
+      var mtimeSpy = futimesSpy.calls[0].arguments[2];
 
       expect(file.stat.mtime).toEqual(new Date(mtimeEarlier));
-      expect(stats.mtime.getTime()).toEqual(mtimeEarlier);
+      expect(mtimeSpy.getTime()).toEqual(mtimeEarlier);
       expect(file.stat.atime).toEqual(new Date(atimeEarlier));
-      expect(stats.atime.getTime()).toEqual(atimeEarlier);
+      expect(atimeSpy.getTime()).toEqual(atimeEarlier);
 
       fs.close(fd, done);
     });
@@ -1193,10 +1195,9 @@ describe('updateMetadata', function() {
     var fchmodSpy = expect.spyOn(fs, 'fchmod').andCallThrough();
     var futimesSpy = expect.spyOn(fs, 'futimes').andCallThrough();
 
-    // Use the mtime/atime of this file to have proper resolution
-    var stats = fs.statSync(__filename);
-    var mtime = stats.mtime;
-    var atime = stats.atime;
+    // Use new atime/mtime
+    var atime = new Date(Date.now() - 2048);
+    var mtime = new Date(Date.now() - 1024);
     var mtimeEarlier = mtime.getTime() - 1000;
     var atimeEarlier = atime.getTime() - 1000;
 
@@ -1219,12 +1220,13 @@ describe('updateMetadata', function() {
       expect(fchmodSpy.calls.length).toEqual(1);
       expect(futimesSpy.calls.length).toEqual(1);
 
-      var stats = fs.fstatSync(fd);
+      var atimeSpy = futimesSpy.calls[0].arguments[1];
+      var mtimeSpy = futimesSpy.calls[0].arguments[2];
 
       expect(file.stat.mtime).toEqual(new Date(mtimeEarlier));
-      expect(stats.mtime.getTime()).toEqual(mtimeEarlier);
+      expect(mtimeSpy.getTime()).toEqual(mtimeEarlier);
       expect(file.stat.atime).toEqual(new Date(atimeEarlier));
-      expect(stats.atime.getTime()).toEqual(atimeEarlier);
+      expect(atimeSpy.getTime()).toEqual(atimeEarlier);
 
       fs.close(fd, done);
     });


### PR DESCRIPTION
- Use `new Date()` instead of `fs.statSync(__filename).mtime` as `file.stat.mtime`
- Fix all cases mentioned in https://github.com/gulpjs/vinyl-fs/issues/208
- Make a note about precision lost in 32bit Node.js