### PR TITLE
Update to eslint@2.13.1, remove jscs

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lib"
   ],
   "scripts": {
-    "lint": "eslint . && jscs index.js lib/ test/",
+    "lint": "eslint -v .",
     "pretest": "npm run lint",
     "test": "mocha --async-only",
     "cover": "istanbul cover _mocha --report lcovonly",
@@ -45,13 +45,12 @@
     "vinyl-sourcemap": "^1.0.0"
   },
   "devDependencies": {
-    "eslint": "^1.10.3",
+    "eslint": "^2.13.1",
     "eslint-config-gulp": "^2.0.0",
     "expect": "^1.19.0",
     "istanbul": "^0.4.3",
     "istanbul-coveralls": "^1.0.3",
-    "jscs": "^2.4.0",
-    "jscs-preset-gulp": "^1.0.0",
+
     "mississippi": "^1.2.0",
     "mocha": "^2.4.5",
     "rimraf": "^2.6.1"


### PR DESCRIPTION
requires related fix gulpjs/eslint-config-gulp#13. 
fixes #263 - Invalid line breaks on Windows 10