### PR TITLE
scaffold: Switch Travis.CI to use "Trusty" distro

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 sudo: required
 language: node_js
 node_js:


### PR DESCRIPTION
Travis.CI builds are [warning](https://travis-ci.org/gulpjs/vinyl-fs/jobs/259003527):

> This job ran on our Precise environment, which is in the process of being decommissioned. Please read about the rollout of Trusty as default on the blog, and take note that you can explicitly stay on Precise by specifying dist: precise in your .travis.yml. 

This PR updates the **.travis.yml** configuration to move to their next-generation distro, "Trusty".   I'm no Linux expert, but It seems to work fine.
