### PR TITLE
Build: enforce consistent line endings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,7 @@ indent_size = 2
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+end_of_line = lf
 
 [*.md]
 trim_trailing_whitespace = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text eol=lf
+


### PR DESCRIPTION
This will enforce *nix line endings even on Windows checkouts, and will inform editorconfig-aware editors of same. If you like this change, we'll probably want it across the various gulpjs repos. Let me know and I'll make a bunch of PRs for it!