### PR TITLE
Upgrade CI scripts and eslint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: required
 language: node_js
 node_js:
+  - node # latest stable node build
   - '6'
   - '5'
   - '4'
@@ -10,5 +11,8 @@ before_script:
   - find test -type d -exec chmod g+s {} \;
   - sudo chown root test/fixtures/not-owned/not-owned.txt
   - sudo chmod 666 test/fixtures/not-owned/not-owned.txt
+script:
+  - if [ "$TRAVIS_NODE_VERSION" == "node" ]; then npm run lint; fi;
+  - npm test
 after_script:
   - npm run coveralls

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,10 +9,12 @@ environment:
     - nodejs_version: "4"
     - nodejs_version: "5"
     - nodejs_version: "6"
+    - nodejs_version: "8"
 
 install:
   - ps: Install-Product node $env:nodejs_version
   - npm install
+  - ps: if ($env:nodejs_version -eq '8') { npm run lint }
 
 test_script:
   - node --version

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   ],
   "scripts": {
     "lint": "eslint . && jscs index.js lib/ test/",
-    "pretest": "npm run lint",
     "test": "mocha --async-only",
     "cover": "istanbul cover _mocha --report lcovonly",
     "coveralls": "npm run cover && istanbul-coveralls"
@@ -45,7 +44,7 @@
     "vinyl-sourcemap": "^1.0.0"
   },
   "devDependencies": {
-    "eslint": "^1.10.3",
+    "eslint": "^4.3.0",
     "eslint-config-gulp": "^2.0.0",
     "expect": "^1.19.0",
     "istanbul": "^0.4.3",

--- a/package.json
+++ b/package.json
@@ -49,8 +49,6 @@
     "expect": "^1.19.0",
     "istanbul": "^0.4.3",
     "istanbul-coveralls": "^1.0.3",
-    "jscs": "^2.4.0",
-    "jscs-preset-gulp": "^1.0.0",
     "mississippi": "^1.2.0",
     "mocha": "^2.4.5",
     "rimraf": "^2.6.1"


### PR DESCRIPTION
- Adds latest stable build of nodejs to test matrix
- Run eslint only on latest stable build of nodejs, not older builds
- Upgrade eslint to latest
- remove obsolete jscs

Note that the build on nodejs@8 will fail with lint errors until PR gulpjs/eslint-config-gulp#13 is merged.   That change is needed for newer versions of eslint.