### PR TITLE
Options refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,14 @@ Type: `Boolean`
 
 Default: `true` (always overwrite existing files)
 
+##### `options.append`
+
+Whether or not new data should be appended after existing file contents (if any).
+
+Type: `Boolean`
+
+Default: `false` (always replace existing contents, if any)
+
 ##### `options.sourcemaps`
 
 Enables sourcemap support on files passed through the stream.  Will write inline soucemaps if specified as `true`.

--- a/lib/dest/options.js
+++ b/lib/dest/options.js
@@ -18,13 +18,6 @@ var config = {
     type: 'boolean',
     default: true,
   },
-  flags: {
-    type: 'string',
-    default: function(file) {
-      var overwrite = this.resolve('overwrite', file);
-      return (overwrite ? 'w': 'wx');
-    },
-  },
   sourcemaps: {
     type: ['string', 'boolean'],
     default: false,

--- a/lib/dest/options.js
+++ b/lib/dest/options.js
@@ -18,6 +18,10 @@ var config = {
     type: 'boolean',
     default: true,
   },
+  append: {
+    type: 'boolean',
+    default: false,
+  },
   sourcemaps: {
     type: ['string', 'boolean'],
     default: false,

--- a/lib/dest/options.js
+++ b/lib/dest/options.js
@@ -18,7 +18,7 @@ var config = {
     type: 'boolean',
     default: true,
   },
-  flag: {
+  flags: {
     type: 'string',
     default: function(file) {
       var overwrite = this.resolve('overwrite', file);

--- a/lib/dest/write-contents/index.js
+++ b/lib/dest/write-contents/index.js
@@ -40,8 +40,8 @@ function writeContents(optResolver) {
     // This is invoked by the various writeXxx modules when they've finished
     // writing the contents.
     function onWritten(writeErr) {
-      var flag = optResolver.resolve('flag', file);
-      if (fo.isFatalOverwriteError(writeErr, flag)) {
+      var flags = optResolver.resolve('flags', file);
+      if (fo.isFatalOverwriteError(writeErr, flags)) {
         return callback(writeErr);
       }
 

--- a/lib/dest/write-contents/index.js
+++ b/lib/dest/write-contents/index.js
@@ -40,7 +40,7 @@ function writeContents(optResolver) {
     // This is invoked by the various writeXxx modules when they've finished
     // writing the contents.
     function onWritten(writeErr) {
-      var flags = optResolver.resolve('flags', file);
+      var flags = fo.getFlags(optResolver.resolve('overwrite', file));
       if (fo.isFatalOverwriteError(writeErr, flags)) {
         return callback(writeErr);
       }

--- a/lib/dest/write-contents/index.js
+++ b/lib/dest/write-contents/index.js
@@ -40,7 +40,10 @@ function writeContents(optResolver) {
     // This is invoked by the various writeXxx modules when they've finished
     // writing the contents.
     function onWritten(writeErr) {
-      var flags = fo.getFlags(optResolver.resolve('overwrite', file));
+      var flags = fo.getFlags({
+        overwrite: optResolver.resolve('overwrite', file),
+        append: optResolver.resolve('append', file),
+      });
       if (fo.isFatalOverwriteError(writeErr, flags)) {
         return callback(writeErr);
       }

--- a/lib/dest/write-contents/write-buffer.js
+++ b/lib/dest/write-contents/write-buffer.js
@@ -3,9 +3,10 @@
 var fo = require('../../file-operations');
 
 function writeBuffer(file, optResolver, onWritten) {
+  var flags = fo.getFlags(optResolver.resolve('overwrite', file));
   var opt = {
     mode: file.stat.mode,
-    flags: optResolver.resolve('flags', file),
+    flags: flags,
   };
 
   fo.writeFile(file.path, file.contents, opt, onWriteFile);

--- a/lib/dest/write-contents/write-buffer.js
+++ b/lib/dest/write-contents/write-buffer.js
@@ -3,7 +3,10 @@
 var fo = require('../../file-operations');
 
 function writeBuffer(file, optResolver, onWritten) {
-  var flags = fo.getFlags(optResolver.resolve('overwrite', file));
+  var flags = fo.getFlags({
+    overwrite: optResolver.resolve('overwrite', file),
+    append: optResolver.resolve('append', file),
+  });
   var opt = {
     mode: file.stat.mode,
     flags: flags,

--- a/lib/dest/write-contents/write-buffer.js
+++ b/lib/dest/write-contents/write-buffer.js
@@ -5,7 +5,7 @@ var fo = require('../../file-operations');
 function writeBuffer(file, optResolver, onWritten) {
   var opt = {
     mode: file.stat.mode,
-    flag: optResolver.resolve('flag', file),
+    flags: optResolver.resolve('flags', file),
   };
 
   fo.writeFile(file.path, file.contents, opt, onWriteFile);

--- a/lib/dest/write-contents/write-stream.js
+++ b/lib/dest/write-contents/write-stream.js
@@ -6,8 +6,8 @@ var readStream = require('../../src/read-contents/read-stream');
 function writeStream(file, optResolver, onWritten) {
   var opt = {
     mode: file.stat.mode,
-    // TODO: need to test this (node calls this `flags` property)
-    flag: optResolver.resolve('flag', file),
+    // TODO: need to test this
+    flags: optResolver.resolve('flags', file),
   };
 
   // TODO: is this the best API?

--- a/lib/dest/write-contents/write-stream.js
+++ b/lib/dest/write-contents/write-stream.js
@@ -4,10 +4,11 @@ var fo = require('../../file-operations');
 var readStream = require('../../src/read-contents/read-stream');
 
 function writeStream(file, optResolver, onWritten) {
+  var flags = fo.getFlags(optResolver.resolve('overwrite', file));
   var opt = {
     mode: file.stat.mode,
     // TODO: need to test this
-    flags: optResolver.resolve('flags', file),
+    flags: flags,
   };
 
   // TODO: is this the best API?

--- a/lib/dest/write-contents/write-stream.js
+++ b/lib/dest/write-contents/write-stream.js
@@ -4,7 +4,10 @@ var fo = require('../../file-operations');
 var readStream = require('../../src/read-contents/read-stream');
 
 function writeStream(file, optResolver, onWritten) {
-  var flags = fo.getFlags(optResolver.resolve('overwrite', file));
+  var flags = fo.getFlags({
+    overwrite: optResolver.resolve('overwrite', file),
+    append: optResolver.resolve('append', file),
+  });
   var opt = {
     mode: file.stat.mode,
     // TODO: need to test this

--- a/lib/dest/write-contents/write-symbolic-link.js
+++ b/lib/dest/write-contents/write-symbolic-link.js
@@ -13,7 +13,10 @@ function writeSymbolicLink(file, optResolver, onWritten) {
   }
 
   var isRelative = optResolver.resolve('relativeSymlinks', file);
-  var flags = fo.getFlags(optResolver.resolve('overwrite', file));
+  var flags = fo.getFlags({
+    overwrite: optResolver.resolve('overwrite', file),
+    append: optResolver.resolve('append', file),
+  });
 
   if (!isWindows) {
     // On non-Windows, just use 'file'

--- a/lib/dest/write-contents/write-symbolic-link.js
+++ b/lib/dest/write-contents/write-symbolic-link.js
@@ -13,7 +13,7 @@ function writeSymbolicLink(file, optResolver, onWritten) {
   }
 
   var isRelative = optResolver.resolve('relativeSymlinks', file);
-  var flag = optResolver.resolve('flag', file);
+  var flags = optResolver.resolve('flags', file);
 
   if (!isWindows) {
     // On non-Windows, just use 'file'
@@ -56,7 +56,7 @@ function writeSymbolicLink(file, optResolver, onWritten) {
     }
 
     var opts = {
-      flag: flag,
+      flags: flags,
       type: type,
     };
     fo.symlink(file.symlink, file.path, opts, onSymlink);

--- a/lib/dest/write-contents/write-symbolic-link.js
+++ b/lib/dest/write-contents/write-symbolic-link.js
@@ -13,7 +13,7 @@ function writeSymbolicLink(file, optResolver, onWritten) {
   }
 
   var isRelative = optResolver.resolve('relativeSymlinks', file);
-  var flags = optResolver.resolve('flags', file);
+  var flags = fo.getFlags(optResolver.resolve('overwrite', file));
 
   if (!isWindows) {
     // On non-Windows, just use 'file'

--- a/lib/file-operations.js
+++ b/lib/file-operations.js
@@ -39,6 +39,10 @@ function isValidUnixId(id) {
   return true;
 }
 
+function getFlags(overwrite) {
+  return !overwrite ? 'wx' : 'w';
+}
+
 function isFatalOverwriteError(err, flags) {
   if (!err) {
     return false;
@@ -435,6 +439,7 @@ function cleanup(callback) {
 module.exports = {
   closeFd: closeFd,
   isValidUnixId: isValidUnixId,
+  getFlags: getFlags,
   isFatalOverwriteError: isFatalOverwriteError,
   isFatalUnlinkError: isFatalUnlinkError,
   getModeDiff: getModeDiff,

--- a/lib/file-operations.js
+++ b/lib/file-operations.js
@@ -39,12 +39,12 @@ function isValidUnixId(id) {
   return true;
 }
 
-function isFatalOverwriteError(err, flag) {
+function isFatalOverwriteError(err, flags) {
   if (!err) {
     return false;
   }
 
-  if (err.code === 'EEXIST' && flag === 'wx') {
+  if (err.code === 'EEXIST' && flags === 'wx') {
     // Handle scenario for file overwrite failures.
     return false;
   }
@@ -274,7 +274,7 @@ function updateMetadata(fd, file, callback) {
 function symlink(srcPath, destPath, opts, callback) {
   // Because fs.symlink does not allow atomic overwrite option with flags, we
   // delete and recreate if the link already exists and overwrite is true.
-  if (opts.flag === 'w') {
+  if (opts.flags === 'w') {
     // TODO What happens when we call unlink with windows junctions?
     fs.unlink(destPath, onUnlink);
   } else {
@@ -289,7 +289,7 @@ function symlink(srcPath, destPath, opts, callback) {
   }
 
   function onSymlink(symlinkErr) {
-    if (isFatalOverwriteError(symlinkErr, opts.flag)) {
+    if (isFatalOverwriteError(symlinkErr, opts.flags)) {
       return callback(symlinkErr);
     }
     callback();
@@ -317,10 +317,10 @@ function writeFile(filepath, data, options, callback) {
 
   // Default the same as node
   var mode = options.mode || constants.DEFAULT_FILE_MODE;
-  var flag = options.flag || 'w';
-  var position = APPEND_MODE_REGEXP.test(flag) ? null : 0;
+  var flags = options.flags || 'w';
+  var position = APPEND_MODE_REGEXP.test(flags) ? null : 0;
 
-  fs.open(filepath, flag, mode, onOpen);
+  fs.open(filepath, flags, mode, onOpen);
 
   function onOpen(openErr, fd) {
     if (openErr) {
@@ -357,7 +357,7 @@ function WriteStream(path, options, flush) {
   this.path = path;
 
   this.mode = options.mode || constants.DEFAULT_FILE_MODE;
-  this.flag = options.flag || 'w';
+  this.flags = options.flags || 'w';
 
   // Used by node's `fs.WriteStream`
   this.fd = null;
@@ -374,7 +374,7 @@ util.inherits(WriteStream, FlushWriteStream);
 WriteStream.prototype.open = function() {
   var self = this;
 
-  fs.open(this.path, this.flag, this.mode, onOpen);
+  fs.open(this.path, this.flags, this.mode, onOpen);
 
   function onOpen(openErr, fd) {
     if (openErr) {

--- a/lib/file-operations.js
+++ b/lib/file-operations.js
@@ -39,8 +39,12 @@ function isValidUnixId(id) {
   return true;
 }
 
-function getFlags(overwrite) {
-  return !overwrite ? 'wx' : 'w';
+function getFlags(options) {
+  var flags = !options.append ? 'w' : 'a';
+  if (!options.overwrite) {
+    flags += 'x';
+  }
+  return flags;
 }
 
 function isFatalOverwriteError(err, flags) {
@@ -48,7 +52,7 @@ function isFatalOverwriteError(err, flags) {
     return false;
   }
 
-  if (err.code === 'EEXIST' && flags === 'wx') {
+  if (err.code === 'EEXIST' && flags[1] === 'x') {
     // Handle scenario for file overwrite failures.
     return false;
   }

--- a/lib/symlink/link-file.js
+++ b/lib/symlink/link-file.js
@@ -13,7 +13,10 @@ function linkStream(optResolver) {
 
   function linkFile(file, enc, callback) {
     var isRelative = optResolver.resolve('relativeSymlinks', file);
-    var flags = fo.getFlags(optResolver.resolve('overwrite', file));
+    var flags = fo.getFlags({
+      overwrite: optResolver.resolve('overwrite', file),
+      append: false,
+    });
 
     if (!isWindows) {
       // On non-Windows, just use 'file'

--- a/lib/symlink/link-file.js
+++ b/lib/symlink/link-file.js
@@ -13,7 +13,7 @@ function linkStream(optResolver) {
 
   function linkFile(file, enc, callback) {
     var isRelative = optResolver.resolve('relativeSymlinks', file);
-    var flag = optResolver.resolve('flag', file);
+    var flags = optResolver.resolve('flags', file);
 
     if (!isWindows) {
       // On non-Windows, just use 'file'
@@ -57,7 +57,7 @@ function linkStream(optResolver) {
       }
 
       var opts = {
-        flag: flag,
+        flags: flags,
         type: type,
       };
       fo.symlink(file.symlink, file.path, opts, onSymlink);

--- a/lib/symlink/link-file.js
+++ b/lib/symlink/link-file.js
@@ -13,7 +13,7 @@ function linkStream(optResolver) {
 
   function linkFile(file, enc, callback) {
     var isRelative = optResolver.resolve('relativeSymlinks', file);
-    var flags = optResolver.resolve('flags', file);
+    var flags = fo.getFlags(optResolver.resolve('overwrite', file));
 
     if (!isWindows) {
       // On non-Windows, just use 'file'

--- a/lib/symlink/options.js
+++ b/lib/symlink/options.js
@@ -21,7 +21,7 @@ var config = {
     type: 'boolean',
     default: true,
   },
-  flag: {
+  flags: {
     type: 'string',
     default: function(file) {
       var overwrite = this.resolve('overwrite', file);

--- a/lib/symlink/options.js
+++ b/lib/symlink/options.js
@@ -21,13 +21,6 @@ var config = {
     type: 'boolean',
     default: true,
   },
-  flags: {
-    type: 'string',
-    default: function(file) {
-      var overwrite = this.resolve('overwrite', file);
-      return (overwrite ? 'w': 'wx');
-    },
-  },
 };
 
 module.exports = config;

--- a/test/dest.js
+++ b/test/dest.js
@@ -606,6 +606,65 @@ describe('.dest()', function() {
     ], done);
   });
 
+  it('appends content with append option set to true', function(done) {
+    var existingContents = 'Lorem Ipsum';
+
+    var file = new File({
+      base: inputBase,
+      path: inputPath,
+      contents: new Buffer(contents),
+    });
+
+    function assert(files) {
+      var outputContents = fs.readFileSync(outputPath, 'utf8');
+
+      expect(files.length).toEqual(1);
+      expect(outputContents).toEqual(existingContents + contents);
+    }
+
+    // This should be overwritten
+    fs.mkdirSync(outputBase);
+    fs.writeFileSync(outputPath, existingContents);
+
+    pipe([
+      from.obj([file]),
+      vfs.dest(outputBase, { append: true }),
+      concat(assert),
+    ], done);
+  });
+
+  it('appends content with append option set to a function that returns true', function(done) {
+    var existingContents = 'Lorem Ipsum';
+
+    var file = new File({
+      base: inputBase,
+      path: inputPath,
+      contents: new Buffer(contents),
+    });
+
+    function append(f) {
+      expect(f).toEqual(file);
+      return true;
+    }
+
+    function assert(files) {
+      var outputContents = fs.readFileSync(outputPath, 'utf8');
+
+      expect(files.length).toEqual(1);
+      expect(outputContents).toEqual(existingContents + contents);
+    }
+
+    // This should be overwritten
+    fs.mkdirSync(outputBase);
+    fs.writeFileSync(outputPath, existingContents);
+
+    pipe([
+      from.obj([file]),
+      vfs.dest(outputBase, { append: append }),
+      concat(assert),
+    ], done);
+  });
+
   it('emits a finish event', function(done) {
     var destStream = vfs.dest(outputBase);
 

--- a/test/file-operations.js
+++ b/test/file-operations.js
@@ -29,6 +29,7 @@ var getModeDiff = fo.getModeDiff;
 var getTimesDiff = fo.getTimesDiff;
 var getOwnerDiff = fo.getOwnerDiff;
 var isValidUnixId = fo.isValidUnixId;
+var getFlags = fo.getFlags;
 var isFatalOverwriteError = fo.isFatalOverwriteError;
 var isFatalUnlinkError = fo.isFatalUnlinkError;
 var reflectStat = fo.reflectStat;
@@ -167,6 +168,25 @@ describe('isValidUnixId', function() {
     var result = isValidUnixId(-1);
 
     expect(result).toEqual(false);
+
+    done();
+  });
+});
+
+describe('getFlags', function() {
+
+  it('returns wx if overwrite is false', function(done) {
+    var result = getFlags(false);
+
+    expect(result).toEqual('wx');
+
+    done();
+  });
+
+  it('returns w if overwrite is true', function(done) {
+    var result = getFlags(true);
+
+    expect(result).toEqual('w');
 
     done();
   });

--- a/test/file-operations.js
+++ b/test/file-operations.js
@@ -175,18 +175,46 @@ describe('isValidUnixId', function() {
 
 describe('getFlags', function() {
 
-  it('returns wx if overwrite is false', function(done) {
-    var result = getFlags(false);
+  it('returns wx if overwrite is false and append is false', function(done) {
+    var result = getFlags({
+      overwrite: false,
+      append: false,
+    });
 
     expect(result).toEqual('wx');
 
     done();
   });
 
-  it('returns w if overwrite is true', function(done) {
-    var result = getFlags(true);
+  it('returns w if overwrite is true and append is false', function(done) {
+    var result = getFlags({
+      overwrite: true,
+      append: false,
+    });
 
     expect(result).toEqual('w');
+
+    done();
+  });
+
+  it('returns ax if overwrite is false and append is true', function(done) {
+    var result = getFlags({
+      overwrite: false,
+      append: true,
+    });
+
+    expect(result).toEqual('ax');
+
+    done();
+  });
+
+  it('returns a if overwrite is true and append is true', function(done) {
+    var result = getFlags({
+      overwrite: true,
+      append: true,
+    });
+
+    expect(result).toEqual('a');
 
     done();
   });
@@ -218,7 +246,15 @@ describe('isFatalOverwriteError', function() {
     done();
   });
 
-  it('returns true if error.code == EEXIST and flags != wx', function(done) {
+  it('returns false if code == EEXIST and flags == ax', function(done) {
+    var result = isFatalOverwriteError({ code: 'EEXIST' }, 'ax');
+
+    expect(result).toEqual(false);
+
+    done();
+  });
+
+  it('returns true if error.code == EEXIST and flags == w', function(done) {
     var result = isFatalOverwriteError({ code: 'EEXIST' }, 'w');
 
     expect(result).toEqual(true);
@@ -226,6 +262,13 @@ describe('isFatalOverwriteError', function() {
     done();
   });
 
+  it('returns true if error.code == EEXIST and flags == a', function(done) {
+    var result = isFatalOverwriteError({ code: 'EEXIST' }, 'a');
+
+    expect(result).toEqual(true);
+
+    done();
+  });
 });
 
 describe('isFatalUnlinkError', function() {

--- a/test/file-operations.js
+++ b/test/file-operations.js
@@ -190,7 +190,7 @@ describe('isFatalOverwriteError', function() {
     done();
   });
 
-  it('returns false if code == EEXIST and flag == wx', function(done) {
+  it('returns false if code == EEXIST and flags == wx', function(done) {
     var result = isFatalOverwriteError({ code: 'EEXIST' }, 'wx');
 
     expect(result).toEqual(false);
@@ -198,7 +198,7 @@ describe('isFatalOverwriteError', function() {
     done();
   });
 
-  it('returns true if error.code == EEXIST and file.flag != wx', function(done) {
+  it('returns true if error.code == EEXIST and flags != wx', function(done) {
     var result = isFatalOverwriteError({ code: 'EEXIST' }, 'w');
 
     expect(result).toEqual(true);
@@ -784,10 +784,10 @@ describe('writeFile', function() {
     });
   });
 
-  it('accepts a different flag in options', function(done) {
+  it('accepts a different flags in options', function(done) {
     var length = contents.length;
     var options = {
-      flag: 'w+',
+      flags: 'w+',
     };
 
     writeFile(outputPath, new Buffer(contents), options, function(err, fd) {
@@ -813,7 +813,7 @@ describe('writeFile', function() {
     var expected = initial + toWrite;
 
     var options = {
-      flag: 'a',
+      flags: 'a',
     };
 
     writeFile(outputPath, new Buffer(toWrite), options, function(err, fd) {
@@ -843,7 +843,7 @@ describe('writeFile', function() {
 
   it('passes a file descriptor if write call errors', function(done) {
     var options = {
-      flag: 'r',
+      flags: 'r',
     };
 
     writeFile(inputPath, new Buffer(contents), options, function(err, fd) {
@@ -1398,7 +1398,7 @@ describe('createWriteStream', function() {
     ], assert);
   });
 
-  it('accepts flag option', function(done) {
+  it('accepts flags option', function(done) {
     // Write 13 stars then 12345 because the length of expected is 13
     fs.writeFileSync(outputPath, '*************12345');
 
@@ -1411,7 +1411,7 @@ describe('createWriteStream', function() {
     pipe([
       from([contents]),
       // Replaces from the beginning of the file
-      createWriteStream(outputPath, { flag: 'r+' }),
+      createWriteStream(outputPath, { flags: 'r+' }),
     ], assert);
   });
 
@@ -1427,7 +1427,7 @@ describe('createWriteStream', function() {
     pipe([
       from([contents]),
       // Appends to the end of the file
-      createWriteStream(outputPath, { flag: 'a' }),
+      createWriteStream(outputPath, { flags: 'a' }),
     ], assert);
   });
 
@@ -1572,7 +1572,7 @@ describe('createWriteStream', function() {
 
     pipe([
       from([contents]),
-      createWriteStream(outputPath, { flag: 'r' }),
+      createWriteStream(outputPath, { flags: 'r' }),
     ], assert);
   });
 });


### PR DESCRIPTION
Cleaned up (IMHO) options handling slightly, in particular prevent users accidentally doing something odd with `flag`. Also, added an `append` option (which I think might come in handy for things like build logs).