### PR TITLE
Fix bom for buffers

### DIFF
--- a/lib/src/getContents/bufferFile.js
+++ b/lib/src/getContents/bufferFile.js
@@ -2,6 +2,7 @@
 
 var fs = require('graceful-fs');
 var stripBom = require('strip-bom');
+var stripBomBuffer = require('strip-bom-buf');
 
 function bufferFile(file, opt, cb) {
   fs.readFile(file.path, function(err, data) {
@@ -10,7 +11,11 @@ function bufferFile(file, opt, cb) {
     }
 
     if (opt.stripBOM) {
-      file.contents = stripBom(data);
+      if (typeof data !== 'string') {
+        file.contents = stripBomBuffer(data);
+      } else {
+        file.contents = stripBom(data);
+      }
     } else {
       file.contents = data;
     }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "object-assign": "^4.0.0",
     "readable-stream": "^2.0.4",
     "strip-bom": "^2.0.0",
+    "strip-bom-buf": "^1.0.0",
     "strip-bom-stream": "^1.0.0",
     "through2": "^2.0.0",
     "through2-filter": "^2.0.0",


### PR DESCRIPTION
Current implementation cause error as `strip-bom` doesn't support buffers anymore. Hope it will pass on Travis, as locally (OSX sierra) one test about time `getTimesDiff makes atime diff undefined if fs and vinyl atime are invalid:` is not passing on your branch when it passes on travis.