### PR TITLE
Do not rely on Node.js internals

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: required
 language: node_js
 node_js:
+  - '9'
   - '8'
   - '6'
   - '5'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,7 @@ environment:
     - nodejs_version: "5"
     - nodejs_version: "6"
     - nodejs_version: "8"
+    - nodejs_version: "9"
 
 install:
   - ps: Install-Product node $env:nodejs_version

--- a/lib/file-operations.js
+++ b/lib/file-operations.js
@@ -398,10 +398,47 @@ WriteStream.prototype.open = function() {
 
 // Use our `end` method since it is patched for flush
 WriteStream.prototype.destroySoon = WriteStream.prototype.end;
-// Use node's `fs.WriteStream` methods
-WriteStream.prototype._destroy = fs.WriteStream.prototype._destroy;
-WriteStream.prototype.destroy = fs.WriteStream.prototype.destroy;
-WriteStream.prototype.close = fs.WriteStream.prototype.close;
+
+WriteStream.prototype._destroy = function(err, cb) {
+  this.close(function(err2) {
+    cb(err || err2);
+  });
+};
+
+WriteStream.prototype.close = function(cb) {
+  var that = this;
+
+  if (cb) {
+    this.once('close', cb);
+  }
+
+  if (this.closed || typeof this.fd !== 'number') {
+    if (typeof this.fd !== 'number') {
+      this.once('open', closeOnOpen);
+      return;
+    }
+
+    return process.nextTick(function() {
+      that.emit('close');
+    });
+  }
+
+  this.closed = true;
+
+  fs.close(this.fd, function(er) {
+    if (er) {
+      that.emit('error', er);
+    } else {
+      that.emit('close');
+    }
+  });
+
+  this.fd = null;
+};
+
+function closeOnOpen() {
+  this.close();
+}
 
 function worker(data, encoding, callback) {
   var self = this;

--- a/lib/file-operations.js
+++ b/lib/file-operations.js
@@ -5,7 +5,7 @@ var util = require('util');
 var fs = require('graceful-fs');
 var assign = require('object.assign');
 var date = require('value-or-function').date;
-var FlushWriteStream = require('flush-write-stream');
+var Writable = require('readable-stream').Writable;
 
 var constants = require('./constants');
 
@@ -359,7 +359,7 @@ function WriteStream(path, options, flush) {
 
   options = options || {};
 
-  FlushWriteStream.call(this, options, worker, cleanup);
+  Writable.call(this, options);
 
   this.flush = flush;
   this.path = path;
@@ -377,7 +377,7 @@ function WriteStream(path, options, flush) {
   this.once('finish', this.close);
 }
 
-util.inherits(WriteStream, FlushWriteStream);
+util.inherits(WriteStream, Writable);
 
 WriteStream.prototype.open = function() {
   var self = this;
@@ -436,11 +436,19 @@ WriteStream.prototype.close = function(cb) {
   this.fd = null;
 };
 
+WriteStream.prototype._final = function(callback) {
+  if (typeof this.flush !== 'function') {
+    return callback();
+  }
+
+  this.flush(this.fd, callback);
+};
+
 function closeOnOpen() {
   this.close();
 }
 
-function worker(data, encoding, callback) {
+WriteStream.prototype._write = function(data, encoding, callback) {
   var self = this;
 
   // This is from node core but I have no idea how to get code coverage on it
@@ -467,15 +475,7 @@ function worker(data, encoding, callback) {
 
     callback();
   }
-}
-
-function cleanup(callback) {
-  if (typeof this.flush !== 'function') {
-    return callback();
-  }
-
-  this.flush(this.fd, callback);
-}
+};
 
 module.exports = {
   closeFd: closeFd,

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "coveralls": "npm run cover && istanbul-coveralls"
   },
   "dependencies": {
-    "flush-write-stream": "^1.0.0",
     "fs-mkdirp-stream": "^1.0.0",
     "glob-stream": "^6.1.0",
     "graceful-fs": "^4.0.0",
@@ -35,6 +34,7 @@
     "lead": "^1.0.0",
     "object.assign": "^4.0.4",
     "pumpify": "^1.3.5",
+    "readable-stream": "^2.3.3",
     "remove-bom-buffer": "^3.0.0",
     "remove-bom-stream": "^1.2.0",
     "resolve-options": "^1.1.0",


### PR DESCRIPTION
This restores compatibility with Node 9 by lifting the code from Node 8.9.4 and copying and pasting it here. This should have been the approach from the very beginning, because vinyl-fs is creating its own WriteStream that has very little in common with the one from Node core.

Unfortunately, pulling functions from a prototype and attaching them to a non-related one is a very dangerous technique: as you can imagine a function attached to a prototype relies on the state that is created by the relative constructor. These are implementation details, and they can surely change across major versions.

As a side note, this was likely broken by https://github.com/nodejs/node/pull/15407 and https://github.com/nodejs/node/pull/18002.

Fixes https://github.com/gulpjs/vinyl-fs/issues/295

---

The actual logic can probably be simplified, because vinyl-fs `WriteStream` implementation is different than the one in Node core.