### PR TITLE
Reference correct property name in integration testing

### DIFF
--- a/test/integration.js
+++ b/test/integration.js
@@ -30,7 +30,7 @@ var inputGlob = path.join(inputBase, './*.txt');
 var outputBase = path.join(base, './out/');
 var outputSymlink = path.join(symlinkDirpath, './foo');
 var outputDirpathSymlink = path.join(outputDirpath, './foo');
-var content = testConstants.content;
+var content = testConstants.contents;
 
 var clean = cleanup(base);
 


### PR DESCRIPTION
testConstants does not have a `content` property, it has a `contents`
property.  Reference the correct name to make tests pass.