### PR TITLE
Bump glob-stream from 6.1.0 to 7.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "fs-mkdirp-stream": "^1.0.0",
-    "glob-stream": "^6.1.0",
+    "glob-stream": "^7.0.0",
     "graceful-fs": "^4.0.0",
     "iconv-lite": "^0.4.24",
     "is-valid-glob": "^1.0.0",


### PR DESCRIPTION
glob-stream@6.1.0 depends on glob-parent@3.1.0, which is affected by regular expression denial of service - https://github.com/advisories/GHSA-ww39-953v-wcq6