### PR TITLE
npm audit fix - Upgrade glob-stream to v7.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "fs-mkdirp-stream": "^1.0.0",
-    "glob-stream": "^6.1.0",
+    "glob-stream": "^7.0.0",
     "graceful-fs": "^4.0.0",
     "iconv-lite": "^0.4.24",
     "is-valid-glob": "^1.0.0",


### PR DESCRIPTION
Include fix for "Regular expression denial of service" in "glob-parent"