### PR TITLE
chore: update glob-stream

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "fs-mkdirp-stream": "^1.0.0",
-    "glob-stream": "^6.1.0",
+    "glob-stream": "^7.0.0",
     "graceful-fs": "^4.0.0",
     "iconv-lite": "^0.4.24",
     "is-valid-glob": "^1.0.0",


### PR DESCRIPTION
The current version of `glob-stream` depends on a version of `glob-parent` that raises a security warning (https://github.com/advisories/GHSA-ww39-953v-wcq6). 

This PR updates `glob-stream` to 7.0.0, which depends on a newer version of `glob-parent` that doesn't present that security issue.