### PR TITLE
feat!: Consider the greater of ctime & mtime when comparing since option

### DIFF
--- a/lib/src/prepare.js
+++ b/lib/src/prepare.js
@@ -6,9 +6,11 @@ function prepareRead(optResolver) {
   function normalize(file, callback) {
     var since = optResolver.resolve('since', file);
 
-    // Skip this file if since option is set and current file is too old
-    if (file.stat && file.stat.mtime <= since) {
-      return callback();
+    if (file.stat) {
+      // Skip this file if since option is set and current file is too old
+      if (Math.max(file.stat.mtime, file.stat.ctime) <= since) {
+        return callback();
+      }
     }
 
     return callback(null, file);

--- a/test/src.js
+++ b/test/src.js
@@ -699,19 +699,21 @@ describeStreams('.src()', function (stream) {
     fs.mkdirSync(outputBase);
     fs.copyFileSync(inputPath, outputPath);
 
-    setTimeout(function () {
-      // chmod changes ctime but not mtime
-      fs.chmodSync(outputPath, parseInt('666', 8));
+    var renamedPath = path.join(outputBase, 'foo.txt');
 
-      var lastMtime = new Date(+fs.statSync(outputPath).mtime);
+    setTimeout(function () {
+      // rename changes ctime but not mtime
+      fs.renameSync(outputPath, renamedPath);
+
+      var lastMtime = new Date(+fs.statSync(renamedPath).mtime);
 
       function assert(files) {
         expect(files.length).toEqual(1);
-        expect(files[0].path).toEqual(outputPath);
+        expect(files[0].path).toEqual(renamedPath);
       }
 
       pipeline(
-        [vfs.src(outputPath, { since: lastMtime }), concatArray(assert)],
+        [vfs.src(renamedPath, { since: lastMtime }), concatArray(assert)],
         done
       );
     }, 250);

--- a/test/src.js
+++ b/test/src.js
@@ -705,7 +705,14 @@ describeStreams('.src()', function (stream) {
       // rename changes ctime but not mtime
       fs.renameSync(outputPath, renamedPath);
 
-      var lastMtime = new Date(+fs.statSync(renamedPath).mtime);
+      var stat = fs.statSync(renamedPath);
+
+      var lastMtime = new Date(+stat.mtime);
+      var lastCtime = new Date(+stat.ctime);
+
+      expect(lastCtime.getMilliseconds()).toBeGreaterThan(
+        lastMtime.getMilliseconds()
+      );
 
       function assert(files) {
         expect(files.length).toEqual(1);

--- a/test/src.js
+++ b/test/src.js
@@ -707,12 +707,9 @@ describeStreams('.src()', function (stream) {
 
       var stat = fs.statSync(renamedPath);
 
-      var lastMtime = new Date(+stat.mtime);
-      var lastCtime = new Date(+stat.ctime);
+      expect(+stat.ctime).toBeGreaterThan(+stat.mtime);
 
-      expect(lastCtime.getMilliseconds()).toBeGreaterThan(
-        lastMtime.getMilliseconds()
-      );
+      var lastMtime = new Date(+stat.mtime);
 
       function assert(files) {
         expect(files.length).toEqual(1);


### PR DESCRIPTION
Closes #226

This adds `ctime` as a property to be considered when `since` filtering. The `ctime` might be changed by some file metadata change and that should be considered a file change.