### PR TITLE
fix!: Avoid error and reflect filesystem stat if futimes not implemented

### DIFF
--- a/lib/file-operations.js
+++ b/lib/file-operations.js
@@ -278,6 +278,13 @@ function updateMetadata(fd, file, callback) {
           file.stat.atime = timesDiff.atime;
           file.stat.mtime = timesDiff.mtime;
         }
+        // If a filesystem doesn't implement futimes, we don't callback with the error.
+        // Instead we update the stats to match filesystem and clear the error.
+        if (futimesErr && futimesErr.code === 'ENOSYS') {
+          file.stat.atime = stat.atime;
+          file.stat.mtime = stat.mtime;
+          futimesErr = null;
+        }
         if (ownerDiff) {
           return owner(propagatedErr || futimesErr);
         }


### PR DESCRIPTION
Closes #302

We attempt to reflect the vinyl stats to the filesystem using `futimes`, but if a system doesn't allow that due to ENOSYS, we don't want to error; however, the vinyl file stats need to match the filesystem stats, so we now sync them with the filesystem stats. This is fixing the issue, but is also a breaking change in how those stats are reflected.