### PR TITLE
fix: Correct regression with src using arrays of globs

### DIFF
--- a/lib/src/index.js
+++ b/lib/src/index.js
@@ -14,6 +14,10 @@ var sourcemap = require('./sourcemap');
 var readContents = require('./read-contents');
 var resolveSymlinks = require('./resolve-symlinks');
 
+function normalize(glob) {
+  return normalizePath(glob, false);
+}
+
 function src(glob, opt) {
   var optResolver = createResolver(config, opt);
 
@@ -21,7 +25,11 @@ function src(glob, opt) {
     throw new Error('Invalid glob argument: ' + glob);
   }
 
-  glob = normalizePath(glob, false);
+  if (!Array.isArray(glob)) {
+    glob = [glob];
+  }
+
+  glob = glob.map(normalize);
 
   var outputStream = pipeline(
     gs(glob, opt),

--- a/test/src.js
+++ b/test/src.js
@@ -110,6 +110,16 @@ describeStreams('.src()', function (stream) {
     }
   });
 
+  it('supports arrays of globs', function (done) {
+    var cwd = path.relative(process.cwd(), __dirname);
+
+    var stream = vfs.src(['./fixtures/test.txt', './fixtures/bom-*.txt'], {
+      cwd: cwd,
+    });
+    expect(stream).toEqual(expect.anything());
+    done();
+  });
+
   it('emits an error on file not existing', function (done) {
     function assert(err) {
       expect(err).toEqual(expect.anything());


### PR DESCRIPTION
I broke `src()` with arrays of globs with my changes in #333

This converts all glob arguments to arrays and then normalize the entire array of globs.