### PR TITLE
fix: Avoid transcoding streaming output with default options

### DIFF
--- a/lib/dest/write-contents/write-stream.js
+++ b/lib/dest/write-contents/write-stream.js
@@ -31,7 +31,7 @@ function writeStream(file, optResolver, onWritten) {
   // TODO: should this use a clone?
   var streams = [file.contents];
 
-  if (encoding && encoding.enc !== DEFAULT_ENCODING) {
+  if (encoding && codec.enc !== DEFAULT_ENCODING) {
     streams.push(getCodec(DEFAULT_ENCODING).decodeStream());
     streams.push(codec.encodeStream());
   }

--- a/test/dest.js
+++ b/test/dest.js
@@ -697,6 +697,31 @@ describeStreams('.dest()', function (stream) {
     );
   });
 
+  it('does not do any transcoding with encoding defaulted (buffer)', function (done) {
+    var expectedContents = fs.readFileSync(ranBomInputPath);
+    var file = new File({
+      base: inputBase,
+      path: inputPath,
+      contents: expectedContents,
+    });
+
+    function assert(files) {
+      var outputContents = fs.readFileSync(outputPath);
+
+      expect(files.length).toEqual(1);
+      expect(outputContents).toEqual(expectedContents);
+    }
+
+    pipeline(
+      [
+        from([file]),
+        vfs.dest(outputBase),
+        concatArray(assert),
+      ],
+      done
+    );
+  });
+
   it('does not do any transcoding with encoding option set to false (buffer)', function (done) {
     var expectedContents = fs.readFileSync(ranBomInputPath);
     var file = new File({
@@ -716,6 +741,31 @@ describeStreams('.dest()', function (stream) {
       [
         from([file]),
         vfs.dest(outputBase, { encoding: false }),
+        concatArray(assert),
+      ],
+      done
+    );
+  });
+
+  it('does not do any transcoding with encoding defaulted (stream)', function (done) {
+    var expectedContents = fs.readFileSync(ranBomInputPath);
+    var file = new File({
+      base: inputBase,
+      path: inputPath,
+      contents: fs.createReadStream(ranBomInputPath),
+    });
+
+    function assert(files) {
+      var outputContents = fs.readFileSync(outputPath);
+
+      expect(files.length).toEqual(1);
+      expect(outputContents).toEqual(expectedContents);
+    }
+
+    pipeline(
+      [
+        from([file]),
+        vfs.dest(outputBase),
         concatArray(assert),
       ],
       done


### PR DESCRIPTION
Closes #351
Closes #352
Closes #357

This fixes the accidental transcoding of streaming contents if no options are specified. I implemented this myself because I wasn't happy with the regression tests in the other PRs.

I verified this via a failing test, then made the fix and verified it was resolved. I also added the same regression test for buffered contents, which had the correct code already.