### PR TITLE
fix: Avoid globbing before read stream is opened

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "fs-mkdirp-stream": "^2.0.1",
-    "glob-stream": "^8.0.0",
+    "glob-stream": "^8.0.3",
     "graceful-fs": "^4.2.11",
     "iconv-lite": "^0.6.3",
     "is-valid-glob": "^1.0.0",


### PR DESCRIPTION
This updates glob-stream to require the latest patch which ensures globs aren't traversed until the read stream is opened. I am hoping this will fix the issue people are encountering where the stream doesn't seem to process their files.